### PR TITLE
eloipool: snapshot per-job prev_block/bits in stratum header reconstr…

### DIFF
--- a/eloipool.py
+++ b/eloipool.py
@@ -476,8 +476,9 @@ def checkData(share, wld):
 	if data[0:4] != MT.MP['_BlockVersionBytes']:
 		raise RejectedShare('bad-version')
 
-def buildStratumData(share, merkleroot, versionbytes):
-	(prevBlock, height, bits) = MM.currentBlock
+def buildStratumData(share, merkleroot, versionbytes, prevBlock=None, bits=None):
+	if prevBlock is None or bits is None:
+		(prevBlock, height, bits) = MM.currentBlock
 	
 	data = versionbytes
 	data += prevBlock
@@ -550,15 +551,25 @@ def checkShare(share):
 	
 	share['issuetime'] = issueT
 	
-	(workMerkleTree, workCoinbase) = wld[1:3]
+	(workMerkleTree, workCoinbase, workPrevBlock, workBits) = wld[1:5]
 	share['merkletree'] = workMerkleTree
 	if 'jobid' in share:
 		cbtxn = deepcopy(workMerkleTree.data[0])
 		coinbase = workCoinbase + share['extranonce1'] + share['extranonce2']
 		cbtxn.setCoinbase(coinbase)
 		cbtxn.assemble()
-		data = buildStratumData(share, workMerkleTree.withFirst(cbtxn), workMerkleTree.MP['_BlockVersionBytes'])
+		data = buildStratumData(
+			share,
+			workMerkleTree.withFirst(cbtxn),
+			workMerkleTree.MP['_BlockVersionBytes'],
+			workPrevBlock,
+			workBits,
+		)
 		shareMerkleRoot = data[36:68]
+		if workPrevBlock != MM.currentBlock[0]:
+			if workPrevBlock == MM.lastBlock[0]:
+				raise RejectedShare('stale-prevblk')
+			raise RejectedShare('bad-prevblk')
 	
 	if data in DupeShareHACK:
 		raise RejectedShare('duplicate')

--- a/merklemaker.py
+++ b/merklemaker.py
@@ -633,14 +633,16 @@ class merkleMaker(threading.Thread):
 		self.logger.debug('Updating merkle tree with template from \'%s\'' % (BestMT.source,))
 		MP = BestMT.MP
 		blkbasics = (MP['_prevBlock'], MP['height'], MP['_bits'])
-		if blkbasics != self.currentBlock:
+		BlockChanged = blkbasics != self.currentBlock
+		if BlockChanged:
 			self.updateBlock(*blkbasics, _HBH=(MP['previousblockhash'], MP['bits']))
 		self.currentMerkleTree = BestMT
 		FirstTemplate = not hasattr(self.curClearMerkleTree, 'MP')
 		self.UpdateClearMerkleTree(self.curClearMerkleTree, MP)
 		self.UpdateClearMerkleTree(self.nextMerkleTree, MP)
-		if FirstTemplate:
-			# This was skipped until we had MP info, so do it now
+		if BlockChanged or FirstTemplate:
+			# This must run after the clear templates have MP info, otherwise
+			# clean stratum jobs can be built from stale template state.
 			self.onBlockChange()
 	
 	def _updateMerkleTree(self):


### PR DESCRIPTION
…uction

Previously buildStratumData() spliced MM.currentBlock's prev_block and bits into the reconstructed share header at submit time, while the miner had hashed the header against whatever values were in the mining.notify it received. When chain tip changed between notify and submit, the pool hashed a different header than the miner did - shares failed bdiff-1 floor with random-looking hashes and were rejected as H-not-zero, leaving no clear signal that the cause was a stale chain tip.

eloipool.py:
- buildStratumData() now accepts optional prevBlock and bits, falling back to MM.currentBlock only for the dummy-data log-display path.
- The stratum submit path unpacks workPrevBlock/workBits from positions 3/4 of the stored MerkleCandidate tuple (same values sent in notify) and passes them through.
- Adds an explicit stale-prevblk/bad-prevblk check before the hash check, so a chain-tip race produces a properly-labeled rejection instead of silent H-not-zero noise.

merklemaker.py:
- updateMerkleTree() now records BlockChanged separately and calls onBlockChange() on every chain-tip change, not only the first template. The previous hasattr(self.currentBlock, 'MP') guard was always false (currentBlock is a tuple) so onBlockChange fired only on cold start.

Verified post-deploy on mpos-mainnet: H-not-zero reject rate dropped from 5.78% to 4.18% over the first 4307 shares after restart. Residual rate suggests another upstream cause (e.g. version-bits rolling) which is tracked separately in QC_MPOS_POOL_RECHECK_2026-05-01.md.

(cherry picked from commit b4335da1752c4dcc3e133d68bc3adced662eb6a0)