### PR TITLE
Fix 25.2 coinbase and aux template handling

### DIFF
--- a/blake8.py
+++ b/blake8.py
@@ -1,0 +1,515 @@
+
+
+intro = """
+    blake.py
+    version 4
+    
+    BLAKE is a SHA3 round-3 finalist designed and submitted by 
+    Jean-Philippe Aumasson et al.
+    
+    At the core of BLAKE is a ChaCha-like mixer, very similar 
+    to that found in the stream cipher, ChaCha8.  Besides being 
+    a very good mixer, ChaCha is fast.  
+    
+    References:
+      http://www.131002.net/blake/
+      http://csrc.nist.gov/groups/ST/hash/sha-3/index.html
+      http://en.wikipedia.org/wiki/BLAKE_(hash_function)
+    
+    This implementation assumes all data is in increments of 
+    whole bytes.  (The formal definition of BLAKE allows for 
+    hashing individual bits.)  Note too that this implementation 
+    does include the round-3 tweaks where the number of rounds 
+    was increased to 14/16 from 10/14.
+    
+    This version can be imported into both Python2 and Python3 
+    programs.
+
+    Here are some comparative run times for different versions 
+    of Python:
+
+        64-bit:
+            2.6         6.28s
+            2.7         6.34s
+            3.2         7.62s
+            pypy (2.7)  2.08s
+
+        32-bit:
+            2.7        13.65s
+            3.2        12.57s
+
+    Another test on a 2.0GHz Core 2 Duo of 10,000 iterations of 
+    BLAKE-256 on a short message produced a time of 5.7 seconds.  
+    Not bad, but if raw speed is what you want, look to the t
+    he C version.  It is 40x faster and did the same thing in 
+    0.13 seconds.
+    
+        Copyright (c) 2009-2012 by Larry Bugbee, Kent, WA
+        ALL RIGHTS RESERVED.
+        
+        blake.py IS EXPERIMENTAL SOFTWARE FOR EDUCATIONAL
+        PURPOSES ONLY.  IT IS MADE AVAILABLE "AS-IS" WITHOUT 
+        WARRANTY OR GUARANTEE OF ANY KIND.  USE SIGNIFIES 
+        ACCEPTANCE OF ALL RISK.  
+
+    To make your learning and experimentation less cumbersome, 
+    blake.py is free for any use.      
+    
+    Enjoy,
+        
+    Larry Bugbee
+    March 2011
+    rev May 2011 - fixed Python version check (tx JP)
+    rev Apr 2012 - fixed an out-of-order bit set in final()
+                 - moved self-test to a separate test pgm
+                 - this now works with Python2 and Python3
+    
+"""
+
+import struct
+
+try:
+    import psyco    # works on some 32-bit Python2 versions only
+    have_psyco = True
+    print('psyco enabled')
+except:
+    have_psyco = False
+    
+#---------------------------------------------------------------
+
+class BLAKE(object):
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # initial values, constants and padding
+    
+    # IVx for BLAKE-x
+    
+    IV64 = [
+        0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
+        0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
+        0x510E527FADE682D1, 0x9B05688C2B3E6C1F,
+        0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179,
+    ]
+    
+    IV48 = [
+        0xCBBB9D5DC1059ED8, 0x629A292A367CD507,
+        0x9159015A3070DD17, 0x152FECD8F70E5939,
+        0x67332667FFC00B31, 0x8EB44A8768581511,
+        0xDB0C2E0D64F98FA7, 0x47B5481DBEFA4FA4,
+    ]
+    
+    # note: the values here are the same as the high-order 
+    #       half-words of IV64
+    IV32 = [
+        0x6A09E667, 0xBB67AE85,
+        0x3C6EF372, 0xA54FF53A,
+        0x510E527F, 0x9B05688C,
+        0x1F83D9AB, 0x5BE0CD19,
+    ]
+    
+    # note: the values here are the same as the low-order 
+    #       half-words of IV48
+    IV28 = [
+        0xC1059ED8, 0x367CD507,
+        0x3070DD17, 0xF70E5939,
+        0xFFC00B31, 0x68581511,
+        0x64F98FA7, 0xBEFA4FA4,
+    ]
+    
+    # constants for BLAKE-64 and BLAKE-48
+    C64 = [
+        0x243F6A8885A308D3, 0x13198A2E03707344,
+        0xA4093822299F31D0, 0x082EFA98EC4E6C89,
+        0x452821E638D01377, 0xBE5466CF34E90C6C,
+        0xC0AC29B7C97C50DD, 0x3F84D5B5B5470917,
+        0x9216D5D98979FB1B, 0xD1310BA698DFB5AC,
+        0x2FFD72DBD01ADFB7, 0xB8E1AFED6A267E96,
+        0xBA7C9045F12C7F99, 0x24A19947B3916CF7,
+        0x0801F2E2858EFC16, 0x636920D871574E69,
+    ]
+    
+    # constants for BLAKE-32 and BLAKE-28
+    # note: concatenate and the values are the same as the values 
+    #       for the 1st half of C64
+    C32 = [
+        0x243F6A88, 0x85A308D3,
+        0x13198A2E, 0x03707344,
+        0xA4093822, 0x299F31D0,
+        0x082EFA98, 0xEC4E6C89,
+        0x452821E6, 0x38D01377,
+        0xBE5466CF, 0x34E90C6C,
+        0xC0AC29B7, 0xC97C50DD,
+        0x3F84D5B5, 0xB5470917,
+    ]
+    
+    # the 10 permutations of:0,...15}
+    SIGMA = [
+        [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15],
+        [14,10, 4, 8, 9,15,13, 6, 1,12, 0, 2,11, 7, 5, 3],
+        [11, 8,12, 0, 5, 2,15,13,10,14, 3, 6, 7, 1, 9, 4],
+        [ 7, 9, 3, 1,13,12,11,14, 2, 6, 5,10, 4, 0,15, 8],
+        [ 9, 0, 5, 7, 2, 4,10,15,14, 1,11,12, 6, 8, 3,13],
+        [ 2,12, 6,10, 0,11, 8, 3, 4,13, 7, 5,15,14, 1, 9],
+        [12, 5, 1,15,14,13, 4,10, 0, 7, 6, 3, 9, 2, 8,11],
+        [13,11, 7,14,12, 1, 3, 9, 5, 0,15, 4, 8, 6, 2,10],
+        [ 6,15,14, 9,11, 3, 0, 8,12, 2,13, 7, 1, 4,10, 5],
+        [10, 2, 8, 4, 7, 6, 1, 5,15,11, 9,14, 3,12,13, 0],
+        [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15],
+        [14,10, 4, 8, 9,15,13, 6, 1,12, 0, 2,11, 7, 5, 3],
+        [11, 8,12, 0, 5, 2,15,13,10,14, 3, 6, 7, 1, 9, 4],
+        [ 7, 9, 3, 1,13,12,11,14, 2, 6, 5,10, 4, 0,15, 8],
+        [ 9, 0, 5, 7, 2, 4,10,15,14, 1,11,12, 6, 8, 3,13],
+        [ 2,12, 6,10, 0,11, 8, 3, 4,13, 7, 5,15,14, 1, 9],
+        [12, 5, 1,15,14,13, 4,10, 0, 7, 6, 3, 9, 2, 8,11],
+        [13,11, 7,14,12, 1, 3, 9, 5, 0,15, 4, 8, 6, 2,10],
+        [ 6,15,14, 9,11, 3, 0, 8,12, 2,13, 7, 1, 4,10, 5],
+        [10, 2, 8, 4, 7, 6, 1, 5,15,11, 9,14, 3,12,13, 0],
+    ]
+        
+    MASK32BITS = 0xFFFFFFFF
+    MASK64BITS = 0xFFFFFFFFFFFFFFFF
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    def __init__(self, hashbitlen):
+        """
+          load the hashSate structure (copy hashbitlen...)
+          hashbitlen: length of the hash output
+        """
+        if hashbitlen not in [224, 256, 384, 512]:
+            raise Exception('hash length not 224, 256, 384 or 512')
+        
+        self.hashbitlen = hashbitlen
+        self.h     = [0]*8  # current chain value (initialized to the IV)
+        self.t     = 0      # number of *BITS* hashed so far
+        self.cache = b''    # cached leftover data not yet compressed
+        self.salt  = [0]*4  # salt (null by default)
+        self.init  = 1      # set to 2 by update and 3 by final
+        self.nullt = 0      # Boolean value for special case \ell_i=0
+        
+        # The algorithm is the same for both the 32- and 64- versions 
+        # of BLAKE.  The difference is in word size (4 vs 8 bytes), 
+        # blocksize (64 vs 128 bytes), number of rounds (14 vs 16)
+        # and a few very specific constants.
+        if (hashbitlen == 224) or (hashbitlen == 256):
+            # setup for 32-bit words and 64-bit block
+            self.byte2int  = self._fourByte2int
+            self.int2byte  = self._int2fourByte
+            self.MASK      = self.MASK32BITS
+            self.WORDBYTES = 4
+            self.WORDBITS  = 32
+            self.BLKBYTES  = 64
+            self.BLKBITS   = 512
+            # self.ROUNDS    = 14   # was 10 before round 3
+            self.ROUNDS    = 8      # BLAKE 8 for blakecoin
+            self.cxx  = self.C32
+            self.rot1 = 16          # num bits to shift in G
+            self.rot2 = 12          # num bits to shift in G 
+            self.rot3 = 8           # num bits to shift in G 
+            self.rot4 = 7           # num bits to shift in G
+            self.mul  = 0   # for 32-bit words, 32<<self.mul where self.mul = 0
+            
+            # 224- and 256-bit versions (32-bit words)
+            if hashbitlen == 224:
+                self.h = self.IV28[:]
+            else:
+                self.h = self.IV32[:]
+    
+        elif (hashbitlen == 384) or (hashbitlen == 512):
+            # setup for 64-bit words and 128-bit block
+            self.byte2int  = self._eightByte2int
+            self.int2byte  = self._int2eightByte
+            self.MASK      = self.MASK64BITS
+            self.WORDBYTES = 8
+            self.WORDBITS  = 64
+            self.BLKBYTES  = 128
+            self.BLKBITS   = 1024
+            self.ROUNDS    = 16     # was 14 before round 3
+            self.cxx  = self.C64
+            self.rot1 = 32          # num bits to shift in G
+            self.rot2 = 25          # num bits to shift in G
+            self.rot3 = 16          # num bits to shift in G
+            self.rot4 = 11          # num bits to shift in G
+            self.mul  = 1   # for 64-bit words, 32<<self.mul where self.mul = 1
+            
+            # 384- and 512-bit versions (64-bit words)
+            if hashbitlen == 384:
+                self.h = self.IV48[:]
+            else:
+                self.h = self.IV64[:]
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    def _compress(self, block):
+        byte2int = self.byte2int
+        mul      = self.mul       # de-reference these for  ...speed?  ;-)
+        cxx      = self.cxx
+        rot1     = self.rot1
+        rot2     = self.rot2
+        rot3     = self.rot3
+        rot4     = self.rot4
+        MASK     = self.MASK
+        WORDBITS = self.WORDBITS
+        SIGMA    = self.SIGMA
+        
+        # get message       (<<2 is the same as *4 but faster)
+        m = [byte2int(block[i<<2<<mul:(i<<2<<mul)+(4<<mul)]) for i in range(16)]        
+        
+        # initialization
+        v = [0]*16
+        v[ 0: 8] = [self.h[i] for i in range(8)]
+        v[ 8:16] = [self.cxx[i] for i in range(8)]
+        v[ 8:12] = [v[8+i] ^ self.salt[i] for i in range(4)]
+        if self.nullt == 0:        #    (i>>1 is the same as i/2 but faster)
+            v[12] = v[12] ^ (self.t & MASK)
+            v[13] = v[13] ^ (self.t & MASK)
+            v[14] = v[14] ^ (self.t >> self.WORDBITS)
+            v[15] = v[15] ^ (self.t >> self.WORDBITS)
+        
+        # - - - - - - - - - - - - - - - - -
+        # ready?  let's ChaCha!!!
+        
+        def G(a, b, c, d, i):
+            va = v[a]   # it's faster to deref and reref later
+            vb = v[b]
+            vc = v[c]
+            vd = v[d]
+            
+            sri  = SIGMA[round][i]
+            sri1 = SIGMA[round][i+1]
+            
+            va = ((va + vb) + (m[sri] ^ cxx[sri1]) ) & MASK
+            x  =  vd ^ va
+            vd = (x >> rot1) | ((x << (WORDBITS-rot1)) & MASK)
+            vc = (vc + vd) & MASK
+            x  =  vb ^ vc
+            vb = (x >> rot2) | ((x << (WORDBITS-rot2)) & MASK)
+            
+            va = ((va + vb) + (m[sri1] ^ cxx[sri]) ) & MASK
+            x  =  vd ^ va
+            vd = (x >> rot3) | ((x << (WORDBITS-rot3)) & MASK)
+            vc = (vc + vd) & MASK
+            x  =  vb ^ vc
+            vb = (x >> rot4) | ((x << (WORDBITS-rot4)) & MASK)
+            
+            v[a] = va
+            v[b] = vb
+            v[c] = vc
+            v[d] = vd
+            
+        for round in range(self.ROUNDS):
+            # column step
+            G( 0, 4, 8,12, 0)
+            G( 1, 5, 9,13, 2)
+            G( 2, 6,10,14, 4)
+            G( 3, 7,11,15, 6)
+            # diagonal step
+            G( 0, 5,10,15, 8)
+            G( 1, 6,11,12,10)
+            G( 2, 7, 8,13,12)
+            G( 3, 4, 9,14,14)
+        
+        # - - - - - - - - - - - - - - - - -
+        
+        # save current hash value   (use i&0x3 to get 0,1,2,3,0,1,2,3)
+        self.h = [self.h[i]^v[i]^v[i+8]^self.salt[i&0x3] 
+                                                for i in range(8)]
+    #    print 'self.h', [num2hex(h) for h in self.h]
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    def addsalt(self, salt):
+        """ adds a salt to the hash function (OPTIONAL)
+            should be called AFTER Init, and BEFORE update
+            salt:  a bytestring, length determined by hashbitlen.
+                   if not of sufficient length, the bytestring 
+                   will be assumed to be a big endian number and 
+                   prefixed with an appropriate number of null 
+                   bytes, and if too large, only the low order 
+                   bytes will be used.
+            
+              if hashbitlen=224 or 256, then salt will be 16 bytes
+              if hashbitlen=384 or 512, then salt will be 32 bytes
+        """
+        # fail if addsalt() was not called at the right time
+        if self.init != 1:
+            raise Exception('addsalt() not called after init() and before update()')
+        # salt size is to be 4x word size
+        saltsize = self.WORDBYTES * 4
+        # if too short, prefix with null bytes.  if too long, 
+        # truncate high order bytes
+        if len(salt) < saltsize:
+            salt = (bytes([0])*(saltsize-len(salt)) + salt)
+        else:
+            salt = salt[-saltsize:]
+        # prep the salt array
+        self.salt[0] = self.byte2int(salt[            : 4<<self.mul])
+        self.salt[1] = self.byte2int(salt[ 4<<self.mul: 8<<self.mul])
+        self.salt[2] = self.byte2int(salt[ 8<<self.mul:12<<self.mul])
+        self.salt[3] = self.byte2int(salt[12<<self.mul:            ])
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    def update(self, data):
+        """ update the state with new data, storing excess data 
+            as necessary.  may be called multiple times and if a 
+            call sends less than a full block in size, the leftover 
+            is cached and will be consumed in the next call 
+            data:  data to be hashed (bytestring)
+        """
+        self.init = 2
+        
+        BLKBYTES = self.BLKBYTES   # de-referenced for improved readability
+        BLKBITS  = self.BLKBITS
+        
+        datalen = len(data)
+        if not datalen:  return
+    
+        left = len(self.cache)
+        fill = BLKBYTES - left
+        
+        # if any cached data and any added new data will fill a 
+        # full block, fill and compress
+        if left and datalen >= fill:
+            self.cache = self.cache + data[:fill]
+            self.t += BLKBITS           # update counter
+            self._compress(self.cache)
+            self.cache = b''
+            data = data[fill:]
+            datalen -= fill
+    
+        # compress new data until not enough for a full block
+        while datalen >= BLKBYTES:        
+            self.t += BLKBITS           # update counter
+            self._compress(data[:BLKBYTES])
+            data = data[BLKBYTES:]
+            datalen -= BLKBYTES
+        
+        # cache all leftover bytes until next call to update()
+        if datalen > 0:
+            self.cache = self.cache + data[:datalen]
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    def final(self, data=''):
+        """ finalize the hash -- pad and hash remaining data
+            returns hashval, the digest
+        """
+        ZZ = b'\x00'
+        ZO = b'\x01'
+        OZ = b'\x80'
+        OO = b'\x81'
+        PADDING = OZ + ZZ*128   # pre-formatted padding data    
+    
+        if data:
+            self.update(data)
+            
+        # copy nb. bits hash in total as a 64-bit BE word
+        # copy nb. bits hash in total as a 128-bit BE word
+        tt = self.t + (len(self.cache) << 3)
+        if self.BLKBYTES == 64:
+            msglen = self._int2eightByte(tt)
+        else:
+            low  = tt & self.MASK
+            high = tt >> self.WORDBITS
+            msglen = self._int2eightByte(high) + self._int2eightByte(low)
+        
+        # size of block without the words at the end that count 
+        # the number of bits, 55 or 111.
+        # Note: (((self.WORDBITS/8)*2)+1) equals ((self.WORDBITS>>2)+1)
+        sizewithout = self.BLKBYTES -  ((self.WORDBITS>>2)+1)
+    
+        if len(self.cache) == sizewithout:
+            # special case of one padding byte
+            self.t -= 8
+            if self.hashbitlen in [224, 384]:
+                self.update(OZ)
+            else:
+                self.update(OO)
+        else:
+            if len(self.cache) < sizewithout:
+                # enough space to fill the block
+                # use t=0 if no remaining data
+                if len(self.cache) == 0:
+                    self.nullt=1
+                self.t -= (sizewithout - len(self.cache)) << 3
+                self.update(PADDING[:sizewithout - len(self.cache)])
+            else: 
+                # NOT enough space, need 2 compressions
+                #   ...add marker, pad with nulls and compress
+                self.t -= (self.BLKBYTES - len(self.cache)) << 3 
+                self.update(PADDING[:self.BLKBYTES - len(self.cache)])
+                #   ...now pad w/nulls leaving space for marker & bit count
+                self.t -= (sizewithout+1) << 3
+                self.update(PADDING[1:sizewithout+1]) # pad with zeroes
+                
+                self.nullt = 1 # raise flag to set t=0 at the next _compress
+            
+            # append a marker byte
+            if self.hashbitlen in [224, 384]:
+                self.update(ZZ)
+            else:
+                self.update(ZO)
+            self.t -= 8
+        
+        # append the number of bits (long long)
+        self.t -= self.BLKBYTES
+        self.update(msglen)
+    
+        hashval = []
+        if self.BLKBYTES == 64:
+            for h in self.h:
+                hashval.append(self._int2fourByte(h))
+        else:
+            for h in self.h:
+                hashval.append(self._int2eightByte(h))
+        return b''.join(hashval)[:self.hashbitlen >> 3]
+    
+    digest = final      # may use digest() as a synonym for final()
+    
+    def midstate(self, data=''):
+    
+        if data:
+            self.update(data)
+
+        hashval = []
+        if self.BLKBYTES == 64:
+            for h in self.h:
+                hashval.append(self._int2fourByte(h))
+        else:
+            for h in self.h:
+                hashval.append(self._int2eightByte(h))
+        return b''.join(hashval)[:self.hashbitlen >> 3]
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # utility functions
+    
+    def _fourByte2int(self, bytestr):      # see also long2byt() below
+        """ convert a 4-byte string to an int (long) """
+        return struct.unpack('!L', bytestr)[0]
+    
+    def _eightByte2int(self, bytestr):
+        """ convert a 8-byte string to an int (long long) """
+        return struct.unpack('!Q', bytestr)[0]
+    
+    def _int2fourByte(self, x):            # see also long2byt() below
+        """ convert a number to a 4-byte string, high order 
+            truncation possible (in Python x could be a BIGNUM)
+        """
+        return struct.pack('!L', x)
+    
+    def _int2eightByte(self, x):
+        """ convert a number to a 8-byte string, high order 
+            truncation possible (in Python x could be a BIGNUM)
+        """
+        return struct.pack('!Q', x)
+    
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    
+    if have_psyco:
+        _compress = psyco.proxy(self._compress)
+
+
+#---------------------------------------------------------------
+#---------------------------------------------------------------
+#---------------------------------------------------------------

--- a/deploy-bundle/cpu_miner.py
+++ b/deploy-bundle/cpu_miner.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Minimal stratum CPU miner for Blakecoin Eloipool staging smoke tests.
+
+This helper is only for low-difficulty local/private smoke tests. It is useful
+for first-run validation of the staged pool, not for serious production
+hashrate.
+
+Run with the pool already running on 127.0.0.1:3334.
+"""
+
+import json
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+from hashlib import sha256
+from pathlib import Path
+
+# Reuse the pool's own Blake-256 implementation so we are guaranteed to be
+# hashing identically to the pool's share validator. Resolve from the current
+# monorepo location so the helper stays portable on the build server.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from blake8 import BLAKE  # noqa: E402
+
+
+import os as _os
+HOST = _os.environ.get('STRATUM_HOST', '127.0.0.1')
+PORT = int(_os.environ.get('STRATUM_PORT', '3334'))
+USERNAME = _os.environ.get('STRATUM_USER', '783c0d31dbf6d7a5bd3d9f9b8e4b3efef0dbe123')
+SHARE_COUNT = int(_os.environ.get('STRATUM_SHARE_COUNT', '1'))
+TARGET_MODE = _os.environ.get('STRATUM_TARGET_MODE', 'effective').strip().lower()
+SOLVER_PATH = _os.environ.get('STRATUM_SOLVER', '').strip()
+DIFF1_TARGET = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(line_buffering=True)
+
+
+def swap32(b):
+    return b''.join(b[i + 3:i - 1 if i else None:-1] for i in range(0, len(b), 4))
+
+
+def dblsha(b):
+    return sha256(sha256(b).digest()).digest()
+
+
+def onesha(b):
+    return sha256(b).digest()
+
+
+def bits_to_target(bits_hex):
+    """eloipool's stratumserver.py:319 sends `b2a_hex(bits[::-1])` where `bits`
+    is the LE form, so the on-the-wire hex is canonical BE (for example
+    '1f00ffff' for a low-difficulty lane)."""
+    bits_be = bytes.fromhex(bits_hex)
+    exponent = bits_be[0]
+    mantissa = int.from_bytes(bits_be[1:4], 'big')
+    return mantissa << (8 * (exponent - 3))
+
+
+class StratumClient:
+    def __init__(self, host, port):
+        self.sock = socket.create_connection((host, port))
+        self.sock.settimeout(15)
+        self.buf = b''
+        self.req_id = 0
+        self.pending = []
+        self.extranonce1 = None
+        self.extranonce2_size = None
+        self.job = None
+        self.network_target = None
+        self.share_difficulty = 1.0
+        self.share_target = DIFF1_TARGET
+        self.effective_target = None
+
+    def _send(self, method, params):
+        self.req_id += 1
+        msg = json.dumps({'id': self.req_id, 'method': method, 'params': params}).encode() + b'\n'
+        self.sock.sendall(msg)
+        return self.req_id
+
+    def _send_reply(self, msg_id, result):
+        """Reply to pool-side JSON-RPC requests such as client.get_version."""
+        msg = json.dumps({'id': msg_id, 'result': result, 'error': None}).encode() + b'\n'
+        self.sock.sendall(msg)
+
+    def _recv_line(self, use_pending=True):
+        if use_pending and self.pending:
+            return self.pending.pop(0)
+        while b'\n' not in self.buf:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise RuntimeError('connection closed')
+            self.buf += chunk
+        line, self.buf = self.buf.split(b'\n', 1)
+        return json.loads(line)
+
+    def subscribe(self):
+        self._send('mining.subscribe', ['cpu_miner/0.1'])
+        while True:
+            msg = self._recv_line()
+            if msg.get('id') == 1 and 'result' in msg:
+                # result = [[ [..], ... ], extranonce1_hex, extranonce2_size]
+                _subs, en1_hex, en2_size = msg['result']
+                self.extranonce1 = bytes.fromhex(en1_hex)
+                self.extranonce2_size = en2_size
+                print(f'[subscribe] extranonce1={en1_hex} en2_size={en2_size}')
+                return
+
+    def authorize(self, username, password=''):
+        auth_id = self._send('mining.authorize', [username, password])
+        while True:
+            # Keep pre-auth notify messages buffered, but do not immediately
+            # read them back from self.pending while we're still waiting for
+            # the auth reply or we can starve that later response forever.
+            msg = self._recv_line(use_pending=False)
+            method = msg.get('method')
+            if method == 'client.get_version' and msg.get('id') is not None:
+                # Some stratum servers probe the miner client version before
+                # they finish the authorize flow. If we do not answer here, the
+                # helper can keep re-queueing the same request and never reach
+                # the auth reply or the first username-specific notify.
+                self._send_reply(msg['id'], 'cpu_miner/0.1')
+                continue
+            if method == 'mining.set_difficulty':
+                diff = msg['params'][0]
+                self.share_difficulty = float(diff)
+                self.share_target = int(DIFF1_TARGET / self.share_difficulty)
+                print(f'[set_difficulty] {diff}')
+                continue
+            if method == 'mining.notify':
+                # Some pool builds already send the first usable job before the
+                # authorize reply comes back. Keep that notify queued so the
+                # miner can begin immediately after auth instead of idling until
+                # the next template refresh.
+                self.pending.append(msg)
+                continue
+            if msg.get('id') == auth_id:
+                if msg.get('result') is not True:
+                    raise RuntimeError(f'authorization failed: {msg}')
+                print(f'[authorize] username={username}')
+                return auth_id
+            self.pending.append(msg)
+
+    def wait_for_job(self):
+        """Drain notifications until we have a mining.notify."""
+        while True:
+            msg = self._recv_line()
+            method = msg.get('method')
+            if method == 'client.get_version' and msg.get('id') is not None:
+                self._send_reply(msg['id'], 'cpu_miner/0.1')
+                continue
+            if method == 'mining.set_difficulty':
+                diff = msg['params'][0]
+                self.share_difficulty = float(diff)
+                self.share_target = int(DIFF1_TARGET / self.share_difficulty)
+                print(f'[set_difficulty] {diff}')
+            elif method == 'mining.notify':
+                p = msg['params']
+                self.job = {
+                    'job_id': p[0],
+                    'prevhash_swapped_hex': p[1],
+                    'coinb1_hex': p[2],
+                    'coinb2_hex': p[3],
+                    'merkle_branch_hex': p[4],
+                    'version_hex': p[5],
+                    'nbits_le_hex': p[6],
+                    'ntime_be_hex': p[7],
+                    'clean_jobs': p[8],
+                }
+                self.network_target = bits_to_target(self.job['nbits_le_hex'])
+                # Two operating modes are useful in QA:
+                # - "effective": ordinary share proofs, accept whichever target
+                #   is easier between the pool share floor and the live network.
+                # - "network": payout proofs, insist on a real network-valid
+                #   block solve so fee-funded payouts become deterministic again.
+                if TARGET_MODE == 'network':
+                    self.effective_target = self.network_target
+                else:
+                    self.effective_target = max(self.network_target, self.share_target)
+                print(f'[notify] job={p[0]} bits={p[6]} ntime={p[7]} branch_len={len(p[4])}')
+                return self.job
+            elif msg.get('id') and 'result' in msg:
+                # Auth response, etc.
+                pass
+
+    def submit(self, username, job_id, en2_hex, ntime_hex, nonce_hex):
+        submit_id = self._send('mining.submit', [username, job_id, en2_hex, ntime_hex, nonce_hex])
+        # Drain replies until we see ours.
+        while True:
+            msg = self._recv_line()
+            if msg.get('method') == 'client.get_version' and msg.get('id') is not None:
+                self._send_reply(msg['id'], 'cpu_miner/0.1')
+                continue
+            if msg.get('id') == submit_id and ('result' in msg or 'error' in msg):
+                return msg
+
+
+def build_header(job, en1, en2, ntime_be_hex, nonce_le):
+    """Construct the 80-byte block header for the given job + extranonce + nonce."""
+    coinbase = (
+        bytes.fromhex(job['coinb1_hex'])
+        + en1
+        + en2
+        + bytes.fromhex(job['coinb2_hex'])
+    )
+    # Blakecoin txid = single SHA-256 (NOT double like Bitcoin).
+    coinbase_txid = onesha(coinbase)
+
+    # Merkle root: walk the branch using double-SHA256 internal combine
+    # (Blakecoin's `Hash4` in src/consensus/merkle.cpp uses dbl-SHA256).
+    root = coinbase_txid
+    for h_hex in job['merkle_branch_hex']:
+        root = dblsha(root + bytes.fromhex(h_hex))
+
+    version_le = struct.pack('<L', int(job['version_hex'], 16))
+    prevhash_le = swap32(bytes.fromhex(job['prevhash_swapped_hex']))
+    ntime_le = bytes.fromhex(ntime_be_hex)[::-1]
+    nbits_le = bytes.fromhex(job['nbits_le_hex'])[::-1]  # stratum sends BE-of-LE; want LE
+    # Wait - re-derive: stratumserver.py:319 sends b2a_hex(bits[::-1]) where `bits`
+    # is the LE form already. So the on-the-wire hex is BE. The header needs LE,
+    # so we reverse the bytes once.
+    nbits_le = bytes.fromhex(job['nbits_le_hex'])[::-1]
+
+    header = version_le + prevhash_le + root + ntime_le + nbits_le + nonce_le
+    assert len(header) == 80, len(header)
+    return header, root
+
+
+def hash_int(h32):
+    return int.from_bytes(h32[::-1], 'big')
+
+
+def solve_with_external_solver(header):
+    result = subprocess.run(
+        [SOLVER_PATH, header.hex()],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f'solver failed: {result.stderr.strip() or result.stdout.strip()}')
+    parts = result.stdout.strip().split()
+    if len(parts) != 2:
+        raise RuntimeError(f'unexpected solver output: {result.stdout!r}')
+    nonce = int(parts[0], 10)
+    hash_hex = parts[1]
+    return nonce, bytes.fromhex(hash_hex)[::-1]
+
+
+def main():
+    cli = StratumClient(HOST, PORT)
+    cli.subscribe()
+    cli.authorize(USERNAME)
+    accepted = 0
+    attempts = 0
+    base_en2 = int.from_bytes(os.urandom(cli.extranonce2_size), 'big')
+    job = None
+
+    while accepted < SHARE_COUNT:
+        if job is None:
+            job = cli.wait_for_job()
+            print(f'[target] network target = 0x{cli.network_target:064x}')
+            print(f'[target] share target   = 0x{cli.share_target:064x}')
+            print(f'[target] mode          = {TARGET_MODE}')
+            print(f'[target] effective tgt  = 0x{cli.effective_target:064x}')
+
+        attempts += 1
+        en1 = cli.extranonce1
+        en2_int = (base_en2 + accepted + attempts - 1) % (1 << (8 * cli.extranonce2_size))
+        en2 = en2_int.to_bytes(cli.extranonce2_size, 'big')
+        ntime = job['ntime_be_hex']
+
+        start = time.time()
+        found = None
+        if SOLVER_PATH:
+            header, root = build_header(job, en1, en2, ntime, struct.pack('<L', 0))
+            nonce, h = solve_with_external_solver(header)
+            if hash_int(h) <= cli.effective_target:
+                found = (nonce, h, root)
+            else:
+                print(f'[solver] found nonce={nonce} hash={h[::-1].hex()} above effective target; waiting for new job')
+        else:
+            for nonce in range(0, 1 << 32):
+                nonce_le = struct.pack('<L', nonce)
+                header, root = build_header(job, en1, en2, ntime, nonce_le)
+                h = BLAKE(256).digest(header)
+                if hash_int(h) <= cli.effective_target:
+                    found = (nonce, h, root)
+                    break
+                if nonce and nonce % 100000 == 0:
+                    print(f'[scan] share={accepted + 1}/{SHARE_COUNT} nonce={nonce} elapsed={time.time()-start:.2f}s')
+
+        if not found:
+            print('FAIL: nonce space exhausted without solve')
+            return 1
+
+        nonce, h, root = found
+        elapsed = time.time() - start
+        print(f'[SOLVED {accepted + 1}/{SHARE_COUNT}] nonce={nonce} en2={en2.hex()} hash={h[::-1].hex()} merkleroot={root[::-1].hex()} elapsed={elapsed:.4f}s')
+
+        nonce_hex = '%08x' % nonce
+        en2_hex = en2.hex()
+        print(f'[submit] job_id={job["job_id"]} en2={en2_hex} ntime={ntime} nonce={nonce_hex}')
+        reply = cli.submit(USERNAME, job['job_id'], en2_hex, ntime, nonce_hex)
+        print(f'[reply] {reply}')
+
+        if reply.get('result') is True:
+            accepted += 1
+            job = None
+            continue
+
+        # The pool likely rolled to a new job while we were scanning; wait for
+        # the next notify and keep filling the requested share batch.
+        job = None
+
+    print(f'[batch] accepted={accepted}/{SHARE_COUNT}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -34,6 +34,10 @@ type CoinbaseParts struct {
 }
 
 func BuildCoinbaseParts(height int64, value int64, scriptPubKey []byte, tag string, auxHex string, extranonceSize int) (CoinbaseParts, error) {
+	return BuildCoinbasePartsWithCommitment(height, value, scriptPubKey, nil, tag, auxHex, extranonceSize)
+}
+
+func BuildCoinbasePartsWithCommitment(height int64, value int64, scriptPubKey []byte, witnessCommitment []byte, tag string, auxHex string, extranonceSize int) (CoinbaseParts, error) {
 	if extranonceSize <= 0 {
 		extranonceSize = 8
 	}
@@ -56,10 +60,19 @@ func BuildCoinbaseParts(height int64, value int64, scriptPubKey []byte, tag stri
 
 	var tail []byte
 	tail = binary.LittleEndian.AppendUint32(tail, 0xffffffff)
-	tail = append(tail, 1)
+	outputCount := byte(1)
+	if len(witnessCommitment) > 0 {
+		outputCount = 2
+	}
+	tail = append(tail, outputCount)
 	tail = binary.LittleEndian.AppendUint64(tail, uint64(value))
 	tail = appendVarInt(tail, uint64(len(scriptPubKey)))
 	tail = append(tail, scriptPubKey...)
+	if len(witnessCommitment) > 0 {
+		tail = binary.LittleEndian.AppendUint64(tail, 0)
+		tail = appendVarInt(tail, uint64(len(witnessCommitment)))
+		tail = append(tail, witnessCommitment...)
+	}
 	tail = binary.LittleEndian.AppendUint32(tail, 0)
 	return CoinbaseParts{Coinbase1: coinbase1, Coinbase2: hex.EncodeToString(tail), ScriptLen: scriptLen}, nil
 }
@@ -114,6 +127,23 @@ func AssembleBlock(header []byte, coinbase []byte, txHex []string) ([]byte, erro
 	return out, nil
 }
 
+func AddZeroReservedWitnessToCoinbase(coinbase []byte) ([]byte, error) {
+	if len(coinbase) < 10 {
+		return nil, fmt.Errorf("coinbase too short: %d bytes", len(coinbase))
+	}
+	witness := make([]byte, 34)
+	witness[0] = 1
+	witness[1] = 32
+	locktimeOffset := len(coinbase) - 4
+	out := make([]byte, 0, len(coinbase)+2+len(witness))
+	out = append(out, coinbase[:4]...)
+	out = append(out, 0x00, 0x01)
+	out = append(out, coinbase[4:locktimeOffset]...)
+	out = append(out, witness...)
+	out = append(out, coinbase[locktimeOffset:]...)
+	return out, nil
+}
+
 func CoinbaseMerkleRoot(coinbase []byte, branches []string) ([]byte, error) {
 	root := OneSHA(coinbase)
 	for _, branchHex := range branches {
@@ -139,6 +169,36 @@ func MerkleBranches(txHex []string) ([]string, error) {
 		}
 		txid := OneSHA(raw)
 		level = append(level, txid)
+	}
+	var branches []string
+	for len(level) > 1 {
+		if len(level) > 1 && level[1] != nil {
+			branches = append(branches, hex.EncodeToString(level[1]))
+		}
+		if len(level)%2 == 1 {
+			level = append(level, level[len(level)-1])
+		}
+		next := [][]byte{nil}
+		for i := 2; i < len(level); i += 2 {
+			next = append(next, DoubleSHA(append(level[i], level[i+1]...)))
+		}
+		level = next
+	}
+	return branches, nil
+}
+
+func MerkleBranchesFromTxIDs(txIDs []string) ([]string, error) {
+	if len(txIDs) == 0 {
+		return nil, nil
+	}
+	level := make([][]byte, 1, len(txIDs)+1)
+	level[0] = nil
+	for _, txidHex := range txIDs {
+		txid, err := hex.DecodeString(txidHex)
+		if err != nil || len(txid) != 32 {
+			return nil, fmt.Errorf("invalid txid %q", txidHex)
+		}
+		level = append(level, ReverseBytes(txid))
 	}
 	var branches []string
 	for len(level) > 1 {
@@ -220,14 +280,32 @@ func encodeScriptNumber(n int64) []byte {
 	if n == 0 {
 		return []byte{0}
 	}
+	if n > 0 && n <= 16 {
+		return []byte{byte(0x50 + n)}
+	}
+	if n == -1 {
+		return []byte{0x4f}
+	}
+	negative := n < 0
 	var encoded []byte
-	value := uint64(n)
+	var value uint64
+	if negative {
+		value = uint64(-n)
+	} else {
+		value = uint64(n)
+	}
 	for value > 0 {
 		encoded = append(encoded, byte(value&0xff))
 		value >>= 8
 	}
 	if encoded[len(encoded)-1]&0x80 != 0 {
-		encoded = append(encoded, 0)
+		if negative {
+			encoded = append(encoded, 0x80)
+		} else {
+			encoded = append(encoded, 0)
+		}
+	} else if negative {
+		encoded[len(encoded)-1] |= 0x80
 	}
 	return append([]byte{byte(len(encoded))}, encoded...)
 }

--- a/internal/block/block_test.go
+++ b/internal/block/block_test.go
@@ -62,6 +62,116 @@ func TestRebuildCoinbase(t *testing.T) {
 	}
 }
 
+func TestEncodeScriptNumberMatchesCoreHeightEncoding(t *testing.T) {
+	tests := map[int64]string{
+		0:   "00",
+		1:   "51",
+		16:  "60",
+		17:  "0111",
+		127: "017f",
+		128: "028000",
+	}
+	for height, want := range tests {
+		if got := hex.EncodeToString(encodeScriptNumber(height)); got != want {
+			t.Fatalf("height %d script number = %s, want %s", height, got, want)
+		}
+	}
+}
+
+func TestBuildCoinbasePartsUsesCoreBIP34HeightEncoding(t *testing.T) {
+	payoutScript, err := hex.DecodeString("001499d7e50d8652fbcd0da10dadee65d37e9d358b3b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts, err := BuildCoinbaseParts(1, 50_00000000, payoutScript, "/GoEloipool/", "", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coinbase1, err := hex.DecodeString(parts.Coinbase1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(coinbase1) < 43 {
+		t.Fatalf("coinbase1 too short: %d bytes", len(coinbase1))
+	}
+	if got := coinbase1[42]; got != 0x51 {
+		t.Fatalf("coinbase height prefix = %02x, want 51", got)
+	}
+}
+
+func TestBuildCoinbasePartsCanAppendWitnessCommitmentOutput(t *testing.T) {
+	payoutScript, err := hex.DecodeString("001499d7e50d8652fbcd0da10dadee65d37e9d358b3b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitment, err := hex.DecodeString("6a24aa21a9ed155e46da836f1785c38aa995b9c8d1c1eb9db9c4a307efbf38d176f7ce152563")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts, err := BuildCoinbasePartsWithCommitment(17, 50_00000000, payoutScript, commitment, "/GoEloipool/", "", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coinbase2, err := hex.DecodeString(parts.Coinbase2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(coinbase2) < 4+1+8+1+len(payoutScript)+8+1+len(commitment)+4 {
+		t.Fatalf("coinbase2 too short: %d", len(coinbase2))
+	}
+	if got := coinbase2[4]; got != 2 {
+		t.Fatalf("output count = %d, want 2", got)
+	}
+	if !bytes.Contains(coinbase2, commitment) {
+		t.Fatalf("coinbase2 does not contain witness commitment %x", commitment)
+	}
+}
+
+func TestAddZeroReservedWitnessToCoinbase(t *testing.T) {
+	payoutScript, err := hex.DecodeString("001499d7e50d8652fbcd0da10dadee65d37e9d358b3b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts, err := BuildCoinbaseParts(17, 50_00000000, payoutScript, "/GoEloipool/", "", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := RebuildCoinbase(parts.Coinbase1, "00000000", "00000000", parts.Coinbase2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withWitness, err := AddZeroReservedWitnessToCoinbase(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(withWitness) != len(legacy)+36 {
+		t.Fatalf("witness coinbase length = %d, want %d", len(withWitness), len(legacy)+36)
+	}
+	if withWitness[4] != 0x00 || withWitness[5] != 0x01 {
+		t.Fatalf("missing segwit marker/flag at offset 4: %x", withWitness[4:6])
+	}
+	witness := withWitness[len(withWitness)-38 : len(withWitness)-4]
+	if witness[0] != 1 || witness[1] != 32 {
+		t.Fatalf("unexpected coinbase witness prefix: %x", witness[:2])
+	}
+	if !bytes.Equal(witness[2:], make([]byte, 32)) {
+		t.Fatalf("reserved witness value is not zero: %x", witness[2:])
+	}
+}
+
+func TestMerkleBranchesFromTxIDsUsesInternalByteOrder(t *testing.T) {
+	branches, err := MerkleBranchesFromTxIDs([]string{
+		"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100"
+	if len(branches) != 1 || branches[0] != want {
+		t.Fatalf("branches = %#v, want [%s]", branches, want)
+	}
+}
+
 func TestReverseBytes(t *testing.T) {
 	input := []byte{0x01, 0x02, 0x03, 0x04}
 	want := []byte{0x04, 0x03, 0x02, 0x01}

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	PollInterval      time.Duration
 	WorkUpdate        time.Duration
 	BaseDifficulty    int
+	ShareTargetHex    string
 	RequireProxyReady bool
 	DebugGotwork      bool
 	StartProxy        bool
@@ -60,6 +61,7 @@ func Parse(args []string) (*Config, error) {
 	fs.DurationVar(&cfg.PollInterval, "poll", 5*time.Second, "parent template poll interval")
 	fs.DurationVar(&cfg.WorkUpdate, "work-update", 55*time.Second, "stratum work refresh interval")
 	fs.IntVar(&cfg.BaseDifficulty, "base-difficulty", 1, "initial stratum share difficulty")
+	fs.StringVar(&cfg.ShareTargetHex, "share-target", envOr("ELIOPOOL_SHARE_TARGET", ""), "explicit 32-byte share target hex override for private/regtest smoke tests")
 	fs.BoolVar(&cfg.RequireProxyReady, "require-proxy-ready", true, "reject stratum shares until merged-mining proxy returns usable aux templates")
 	fs.BoolVar(&cfg.DebugGotwork, "debug-gotwork", false, "log full gotwork coinbase-merkle payloads for auxpow debugging")
 	fs.BoolVar(&cfg.StartProxy, "start-proxy", true, "start the embedded Go merged-mining proxy")

--- a/internal/pool/service.go
+++ b/internal/pool/service.go
@@ -87,6 +87,11 @@ func NewService(cfg *Config, logger *slog.Logger) (*Service, error) {
 	if err := wm.SetShareDifficulty(baseDifficulty); err != nil {
 		return nil, fmt.Errorf("share difficulty: %w", err)
 	}
+	if cfg.ShareTargetHex != "" {
+		if err := wm.SetShareTargetHex(cfg.ShareTargetHex); err != nil {
+			return nil, fmt.Errorf("share target: %w", err)
+		}
+	}
 	script, err := payoutScript(cfg)
 	if err != nil {
 		return nil, err
@@ -340,19 +345,33 @@ func (s *Service) SubmitShare(ctx context.Context, sub share.Submission) share.R
 	parentAccepted := false
 	parentStatus := "parent-rejected"
 	if parentTargetMet {
-		payload, err := block.AssembleBlock(header, coinbase, job.Template.Transactions)
-		if err != nil {
-			parentStatus = "parent-assemble-failed"
-			s.logger.Warn("failed to assemble parent block", "error", err)
-		} else {
-			raw, err := s.parent.Call(ctx, "submitblock", hex.EncodeToString(payload))
-			parentAccepted, parentStatus = parentSubmitStatus(raw, err)
-			if parentAccepted {
-				s.parentFound.Add(1)
-			} else if err != nil {
-				s.logger.Warn("parent submitblock failed", "status", parentStatus, "error", err)
+		submitCoinbase := coinbase
+		coinbaseReady := true
+		if job.Template.WitnessCommitment != "" {
+			withWitness, witnessErr := block.AddZeroReservedWitnessToCoinbase(coinbase)
+			if witnessErr != nil {
+				parentStatus = "parent-coinbase-witness-failed"
+				coinbaseReady = false
+				s.logger.Warn("failed to add parent coinbase witness", "error", witnessErr)
 			} else {
-				s.logger.Warn("parent submitblock rejected", "status", parentStatus, "result", strings.TrimSpace(string(raw)))
+				submitCoinbase = withWitness
+			}
+		}
+		if coinbaseReady {
+			payload, err := block.AssembleBlock(header, submitCoinbase, job.Template.Transactions)
+			if err != nil {
+				parentStatus = "parent-assemble-failed"
+				s.logger.Warn("failed to assemble parent block", "error", err)
+			} else {
+				raw, err := s.parent.Call(ctx, "submitblock", hex.EncodeToString(payload))
+				parentAccepted, parentStatus = parentSubmitStatus(raw, err)
+				if parentAccepted {
+					s.parentFound.Add(1)
+				} else if err != nil {
+					s.logger.Warn("parent submitblock failed", "status", parentStatus, "error", err)
+				} else {
+					s.logger.Warn("parent submitblock rejected", "status", parentStatus, "result", strings.TrimSpace(string(raw)))
+				}
 			}
 		}
 	}

--- a/internal/pool/service_test.go
+++ b/internal/pool/service_test.go
@@ -109,6 +109,17 @@ func TestParseBaseDifficulty(t *testing.T) {
 	}
 }
 
+func TestParseShareTargetOverride(t *testing.T) {
+	target := "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	cfg, err := Parse([]string{"--start-proxy=false", "--share-target", target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ShareTargetHex != target {
+		t.Fatalf("share target = %q, want %q", cfg.ShareTargetHex, target)
+	}
+}
+
 func TestParentSubmitStatusReflectsDaemonResult(t *testing.T) {
 	accepted, status := parentSubmitStatus(json.RawMessage("null"), nil)
 	if !accepted || status != "parent-accepted" {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -29,7 +29,7 @@ const (
 	deploymentCacheTTL   = 2 * time.Minute
 	maxRPCBodyBytes      = 1 << 20
 	perSolverCacheLimit  = 1024
-	merkleTreesToKeep    = 240
+	merkleTreesToKeep    = 2048
 	statusReportInterval = 5 * time.Minute
 )
 
@@ -51,6 +51,8 @@ type merkleMeta struct {
 	ChainIndices    map[int]int
 	AuxHashes       map[int]string
 	PayoutAddresses []string
+	Created         time.Time
+	Global          bool
 }
 
 type cacheEntry struct {
@@ -398,9 +400,18 @@ func (l *Listener) rpcGotwork(solution types.GotWorkRequest) bool {
 
 	l.mu.RLock()
 	meta := l.merkleTrees[merkleRoot]
+	storedRoots := len(l.merkleTrees)
+	queueLen := len(l.merkleTreeQueue)
+	recentRoots := l.recentMerkleRootsLocked(8)
 	l.mu.RUnlock()
 	if meta == nil {
-		l.logger.Warn("Unknown merkle root; skipping aux submission", "root", shortHex(merkleRoot))
+		l.logger.Warn("Unknown merkle root; skipping aux submission",
+			"root", shortHex(merkleRoot),
+			"stored_roots", storedRoots,
+			"queue_len", queueLen,
+			"capacity", merkleTreesToKeep,
+			"recent_roots", recentRoots,
+		)
 		return false
 	}
 
@@ -917,21 +928,15 @@ func (l *Listener) buildAuxTemplate(ctx context.Context, payoutAddresses []strin
 	mmaux := merkleRoot + encodeLE32Hex(uint32(l.merkleSize)) + encodeLE32Hex(nonce)
 
 	l.mu.Lock()
-	if _, exists := l.merkleTrees[merkleRoot]; !exists {
-		l.merkleTrees[merkleRoot] = &merkleMeta{
-			Tree:            merkleTree,
-			Nonce:           nonce,
-			ChainIndices:    chainIndices,
-			AuxHashes:       auxBlockHashes,
-			PayoutAddresses: append([]string(nil), payouts...),
-		}
-		l.merkleTreeQueue = append(l.merkleTreeQueue, merkleRoot)
-		if len(l.merkleTreeQueue) > merkleTreesToKeep {
-			old := l.merkleTreeQueue[0]
-			l.merkleTreeQueue = l.merkleTreeQueue[1:]
-			delete(l.merkleTrees, old)
-		}
-	}
+	l.rememberMerkleTree(merkleRoot, &merkleMeta{
+		Tree:            merkleTree,
+		Nonce:           nonce,
+		ChainIndices:    chainIndices,
+		AuxHashes:       auxBlockHashes,
+		PayoutAddresses: append([]string(nil), payouts...),
+		Created:         time.Now(),
+		Global:          globalTemplate,
+	})
 	if propagateParent {
 		l.perSolverCache = make(map[string]cacheEntry)
 		l.perSolverCacheOrder = nil
@@ -1016,6 +1021,38 @@ func (l *Listener) normalizePayoutAddresses(input []string) []string {
 		}
 	}
 	return out
+}
+
+func (l *Listener) rememberMerkleTree(root string, meta *merkleMeta) {
+	if l.merkleTrees == nil {
+		l.merkleTrees = make(map[string]*merkleMeta)
+	}
+	if _, exists := l.merkleTrees[root]; exists {
+		return
+	}
+	l.merkleTrees[root] = meta
+	l.merkleTreeQueue = append(l.merkleTreeQueue, root)
+	if len(l.merkleTreeQueue) <= merkleTreesToKeep {
+		return
+	}
+	old := l.merkleTreeQueue[0]
+	l.merkleTreeQueue = l.merkleTreeQueue[1:]
+	delete(l.merkleTrees, old)
+}
+
+func (l *Listener) recentMerkleRootsLocked(limit int) []string {
+	if limit <= 0 || len(l.merkleTreeQueue) == 0 {
+		return nil
+	}
+	start := len(l.merkleTreeQueue) - limit
+	if start < 0 {
+		start = 0
+	}
+	roots := make([]string, 0, len(l.merkleTreeQueue)-start)
+	for _, root := range l.merkleTreeQueue[start:] {
+		roots = append(roots, shortHex(root))
+	}
+	return roots
 }
 
 func (l *Listener) chainID(chain int) (int, bool) {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -304,6 +304,34 @@ func TestGotworkSkipsChainsMissingFromTemplate(t *testing.T) {
 	}
 }
 
+func TestMerkleRootCacheEvictsOldestAfterCapacity(t *testing.T) {
+	l := &Listener{merkleTrees: make(map[string]*merkleMeta)}
+	for i := 0; i < merkleTreesToKeep+2; i++ {
+		root := fmt.Sprintf("%064x", i)
+		l.rememberMerkleTree(root, &merkleMeta{})
+	}
+	if len(l.merkleTrees) != merkleTreesToKeep {
+		t.Fatalf("stored merkle roots = %d, want %d", len(l.merkleTrees), merkleTreesToKeep)
+	}
+	if len(l.merkleTreeQueue) != merkleTreesToKeep {
+		t.Fatalf("merkle root queue = %d, want %d", len(l.merkleTreeQueue), merkleTreesToKeep)
+	}
+	for _, evicted := range []string{fmt.Sprintf("%064x", 0), fmt.Sprintf("%064x", 1)} {
+		if _, ok := l.merkleTrees[evicted]; ok {
+			t.Fatalf("old merkle root %s was not evicted", shortHex(evicted))
+		}
+	}
+	for _, retained := range []string{
+		fmt.Sprintf("%064x", 2),
+		fmt.Sprintf("%064x", merkleTreesToKeep),
+		fmt.Sprintf("%064x", merkleTreesToKeep+1),
+	} {
+		if _, ok := l.merkleTrees[retained]; !ok {
+			t.Fatalf("expected merkle root %s to be retained", shortHex(retained))
+		}
+	}
+}
+
 func TestSubmitAuxpowRequiresPayoutAndDoesNotCallGetauxblock(t *testing.T) {
 	var submitCount atomic.Int64
 	aux := jsonRPCServer(t, map[string]rpcReply{

--- a/internal/work/template.go
+++ b/internal/work/template.go
@@ -15,18 +15,20 @@ import (
 )
 
 type Template struct {
-	Version          uint32
-	PreviousBlockHex string
-	PreviousBlockLE  []byte
-	BitsHex          string
-	BitsLE           []byte
-	CurTime          uint32
-	Height           int64
-	CoinbaseValue    int64
-	Transactions     []string
-	Rules            []string
-	Raw              map[string]interface{}
-	Updated          time.Time
+	Version           uint32
+	PreviousBlockHex  string
+	PreviousBlockLE   []byte
+	BitsHex           string
+	BitsLE            []byte
+	CurTime           uint32
+	Height            int64
+	CoinbaseValue     int64
+	Transactions      []string
+	TransactionIDs    []string
+	WitnessCommitment string
+	Rules             []string
+	Raw               map[string]interface{}
+	Updated           time.Time
 }
 
 type Job struct {
@@ -84,6 +86,16 @@ func (m *Manager) SetShareDifficulty(diff int) error {
 	return nil
 }
 
+func (m *Manager) SetShareTargetHex(target string) error {
+	if _, err := block.TargetFromHex(target); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.target = target
+	return nil
+}
+
 func (m *Manager) Current() *Job {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -133,13 +145,20 @@ func (m *Manager) JobWithAux(auxHex string) (*Job, error) {
 }
 
 func (m *Manager) buildJobLocked(tpl *Template, auxHex string) (*Job, error) {
-	branches, err := block.MerkleBranches(tpl.Transactions)
+	branches, err := merkleBranches(tpl)
 	if err != nil {
 		return nil, err
 	}
+	var witnessCommitment []byte
+	if tpl.WitnessCommitment != "" {
+		witnessCommitment, err = hex.DecodeString(tpl.WitnessCommitment)
+		if err != nil {
+			return nil, fmt.Errorf("decode witness commitment: %w", err)
+		}
+	}
 	// Coinbase1/2 are split around extranonce fields because Stratum miners
 	// supply extranonce2 while the server owns extranonce1.
-	parts, err := block.BuildCoinbaseParts(tpl.Height, tpl.CoinbaseValue, m.payoutScript, m.coinbaseTag, auxHex, 8)
+	parts, err := block.BuildCoinbasePartsWithCommitment(tpl.Height, tpl.CoinbaseValue, m.payoutScript, witnessCommitment, m.coinbaseTag, auxHex, 8)
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +212,7 @@ func ParseTemplate(raw json.RawMessage) (*Template, error) {
 	if cv, err := asInt64(payload["coinbasevalue"]); err == nil {
 		t.CoinbaseValue = cv
 	}
+	t.WitnessCommitment, _ = payload["default_witness_commitment"].(string)
 	if rules, ok := payload["rules"].([]interface{}); ok {
 		for _, rule := range rules {
 			if s, ok := rule.(string); ok {
@@ -205,11 +225,29 @@ func ParseTemplate(raw json.RawMessage) (*Template, error) {
 			if m, ok := tx.(map[string]interface{}); ok {
 				if data, ok := m["data"].(string); ok && data != "" {
 					t.Transactions = append(t.Transactions, data)
+					txid, _ := m["txid"].(string)
+					t.TransactionIDs = append(t.TransactionIDs, txid)
 				}
 			}
 		}
 	}
 	return t, nil
+}
+
+func merkleBranches(tpl *Template) ([]string, error) {
+	if len(tpl.TransactionIDs) == len(tpl.Transactions) {
+		complete := true
+		for _, txid := range tpl.TransactionIDs {
+			if txid == "" {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			return block.MerkleBranchesFromTxIDs(tpl.TransactionIDs)
+		}
+	}
+	return block.MerkleBranches(tpl.Transactions)
 }
 
 func asInt64(v interface{}) (int64, error) {

--- a/internal/work/template_test.go
+++ b/internal/work/template_test.go
@@ -1,0 +1,38 @@
+package work
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseTemplateKeepsTransactionIDsForMerkleBranches(t *testing.T) {
+	raw, err := json.Marshal(map[string]interface{}{
+		"version":           0x20000000,
+		"previousblockhash": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+		"bits":              "207fffff",
+		"curtime":           1,
+		"height":            1,
+		"coinbasevalue":     50_00000000,
+		"transactions": []map[string]interface{}{
+			{
+				"data": "01000000000000000000",
+				"txid": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpl, err := ParseTemplate(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branches, err := merkleBranches(tpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "3f3e3d3c3b3a393837363534333231302f2e2d2c2b2a29282726252423222120"
+	if len(branches) != 1 || branches[0] != want {
+		t.Fatalf("branches = %#v, want [%s]", branches, want)
+	}
+}

--- a/scripts/current_testnet_pool.py
+++ b/scripts/current_testnet_pool.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Persistent private 25.2 testnet pool controller for DEX QA.
+
+This script deliberately uses a RAM runtime root and leaves existing daemon
+data directories alone. It starts a local-only private testnet stack:
+
+  BLC parent daemon + BBTC/ELT/LIT/PHO/UMO AuxPoW child daemons
+  Go Eloipool stratum/proxy/dashboard
+  bundled CPU miner loop
+
+It is for feature readiness testing only. It never touches mainnet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(os.environ.get("DEX25_TESTNET_POOL_ROOT", "/mnt/ram-build/dex25-current-testnet-pool"))
+STAGE_ROOT = Path(os.environ.get("DEX25_STAGE_ROOT", "/mnt/ram-build/dex25-hub-qa-20260526"))
+POOL_BIN = Path(os.environ.get("DEX25_ELOIPOOL_BIN", str(STAGE_ROOT / "eliopool" / "bin" / "eloipool")))
+CPU_MINER = Path(os.environ.get("DEX25_CPU_MINER", str(STAGE_ROOT / "eliopool" / "deploy-bundle" / "cpu_miner.py")))
+RPC_USER = os.environ.get("DEX25_TESTNET_RPC_USER", "dex-testnet")
+RPC_PASSWORD = os.environ.get("DEX25_TESTNET_RPC_PASSWORD", "dex-testnet-pass")
+
+
+@dataclass(frozen=True)
+class Coin:
+    ticker: str
+    coin_name: str
+    daemon_name: str
+    cli_name: str
+    rpc_port: int
+    p2p_port: int
+    peer_rpc_port: int
+    peer_p2p_port: int
+    aux_name: str | None = None
+
+    @property
+    def data_dir(self) -> Path:
+        return ROOT / "daemon-data" / self.ticker
+
+    @property
+    def binary(self) -> Path:
+        return ROOT / "bin" / self.ticker / self.daemon_name
+
+    @property
+    def peer_data_dir(self) -> Path:
+        return ROOT / "daemon-peer-data" / self.ticker
+
+    @property
+    def log_file(self) -> Path:
+        return ROOT / "logs" / f"{self.ticker}-daemon.log"
+
+    @property
+    def peer_log_file(self) -> Path:
+        return ROOT / "peer-logs" / f"{self.ticker}-peer.log"
+
+    @property
+    def pid_file(self) -> Path:
+        return ROOT / "run" / f"{self.ticker}.pid"
+
+    @property
+    def peer_pid_file(self) -> Path:
+        return ROOT / "run" / f"{self.ticker}-peer.pid"
+
+
+COINS: list[Coin] = [
+    Coin("BLC", "Blakecoin", "blakecoind", "blakecoin-cli", 59320, 60320, 59420, 60420),
+    Coin("BBTC", "BlakeBitcoin", "blakebitcoind", "blakebitcoin-cli", 59322, 60322, 59422, 60422, "BlakeBitcoin"),
+    Coin("ELT", "Electron", "electrond", "electron-cli", 59324, 60324, 59424, 60424, "Electron"),
+    Coin("LIT", "Lithium", "lithiumd", "lithium-cli", 59326, 60326, 59426, 60426, "Lithium"),
+    Coin("PHO", "Photon", "photond", "photon-cli", 59328, 60328, 59428, 60428, "Photon"),
+    Coin("UMO", "UniversalMolecule", "universalmoleculed", "universalmolecule-cli", 59330, 60330, 59430, 60430, "UniversalMolecule"),
+]
+
+
+def coin_by_ticker(ticker: str) -> Coin:
+    for coin in COINS:
+        if coin.ticker == ticker.upper():
+            return coin
+    raise SystemExit(f"unknown ticker: {ticker}")
+
+
+def ensure_dirs() -> None:
+    for path in (ROOT / "bin", ROOT / "daemon-data", ROOT / "daemon-peer-data", ROOT / "logs", ROOT / "peer-logs", ROOT / "run", ROOT / "evidence"):
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def read_pid(path: Path) -> int | None:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if raw.isdigit():
+        return int(raw)
+    return None
+
+
+def pid_running(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def port_open(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        return sock.connect_ex((host, port)) == 0
+
+
+def rpc_url(coin: Coin, wallet: str | None = None, *, peer: bool = False) -> str:
+    suffix = f"/wallet/{wallet}" if wallet else ""
+    port = coin.peer_rpc_port if peer else coin.rpc_port
+    return f"http://127.0.0.1:{port}{suffix}"
+
+
+def rpc_call(coin: Coin, method: str, params: list[Any] | None = None, wallet: str | None = None, timeout: float = 10.0, *, peer: bool = False) -> Any:
+    body = json.dumps({"jsonrpc": "2.0", "id": "dex25-testnet", "method": method, "params": params or []}).encode("utf-8")
+    token = base64.b64encode(f"{RPC_USER}:{RPC_PASSWORD}".encode("utf-8")).decode("ascii")
+    request = urllib.request.Request(
+        rpc_url(coin, wallet, peer=peer),
+        data=body,
+        headers={"Authorization": f"Basic {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+        except Exception:
+            raise RuntimeError(f"{coin.ticker} RPC {method} HTTP {exc.code}") from exc
+    if payload.get("error"):
+        raise RuntimeError(f"{coin.ticker} RPC {method}: {payload['error']}")
+    return payload.get("result")
+
+
+def wait_rpc(coin: Coin, timeout: float = 60.0) -> None:
+    deadline = time.time() + timeout
+    last_error = ""
+    while time.time() < deadline:
+        try:
+            rpc_call(coin, "getblockchaininfo", timeout=2)
+            return
+        except Exception as exc:
+            last_error = str(exc)
+            time.sleep(0.5)
+    raise RuntimeError(f"{coin.ticker} RPC did not become ready: {last_error}")
+
+
+def source_binary(coin: Coin) -> Path:
+    repo_map = {
+        "BLC": Path("/home/sid/Blakestream-Installer/repos/Blakecoin-0.25.2/src/blakecoind"),
+        "BBTC": Path("/home/sid/Blakestream-Installer/repos/BlakeBitcoin-0.25.2/src/blakebitcoind"),
+        "ELT": Path("/home/sid/Blakestream-Installer/repos/Electron-ELT-0.25.2/src/electrond"),
+        "LIT": Path("/home/sid/Blakestream-Installer/repos/lithium-0.25.2/src/lithiumd"),
+        "PHO": Path("/home/sid/Blakestream-Installer/repos/Photon-0.25.2/src/photond"),
+        "UMO": Path("/home/sid/Blakestream-Installer/repos/universalmolecule-0.25.2/src/universalmoleculed"),
+    }
+    candidate = repo_map.get(coin.ticker)
+    if candidate and candidate.exists():
+        return candidate
+    staged = STAGE_ROOT / "daemons" / coin.ticker / coin.daemon_name
+    if staged.exists():
+        return staged
+    raise FileNotFoundError(f"missing daemon binary for {coin.ticker}")
+
+
+def install_binaries(force: bool = False) -> dict[str, str]:
+    ensure_dirs()
+    installed: dict[str, str] = {}
+    for coin in COINS:
+        src = source_binary(coin)
+        dst = coin.binary
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if force or not dst.exists() or src.stat().st_mtime > dst.stat().st_mtime:
+            subprocess.run(["cp", "-f", str(src), str(dst)], check=True)
+            dst.chmod(0o755)
+        installed[coin.ticker] = str(dst)
+    return installed
+
+
+def start_daemon(coin: Coin) -> None:
+    if pid_running(read_pid(coin.pid_file)) or port_open("127.0.0.1", coin.rpc_port):
+        return
+    coin.data_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(coin.binary),
+        "-testnet=1",
+        f"-datadir={coin.data_dir}",
+        "-server=1",
+        "-listen=1",
+        "-dnsseed=0",
+        "-fixedseeds=0",
+        "-discover=0",
+        "-listenonion=0",
+        "-maxtipage=3153600000",
+        "-txindex=1",
+        "-fallbackfee=0.0001",
+        "-bind=127.0.0.1",
+        "-rpcbind=127.0.0.1",
+        "-rpcallowip=127.0.0.1",
+        f"-rpcuser={RPC_USER}",
+        f"-rpcpassword={RPC_PASSWORD}",
+        f"-rpcport={coin.rpc_port}",
+        f"-port={coin.p2p_port}",
+    ]
+    with coin.log_file.open("ab") as log:
+        proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    coin.pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+
+
+def start_peer_daemon(coin: Coin) -> None:
+    if pid_running(read_pid(coin.peer_pid_file)) or port_open("127.0.0.1", coin.peer_rpc_port):
+        return
+    coin.peer_data_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(coin.binary),
+        "-testnet=1",
+        f"-datadir={coin.peer_data_dir}",
+        "-server=1",
+        "-listen=1",
+        "-dnsseed=0",
+        "-fixedseeds=0",
+        "-discover=0",
+        "-listenonion=0",
+        "-maxtipage=3153600000",
+        "-txindex=1",
+        "-fallbackfee=0.0001",
+        "-bind=127.0.0.1",
+        "-rpcbind=127.0.0.1",
+        "-rpcallowip=127.0.0.1",
+        f"-rpcuser={RPC_USER}",
+        f"-rpcpassword={RPC_PASSWORD}",
+        f"-rpcport={coin.peer_rpc_port}",
+        f"-port={coin.peer_p2p_port}",
+        f"-connect=127.0.0.1:{coin.p2p_port}",
+    ]
+    with coin.peer_log_file.open("ab") as log:
+        proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    coin.peer_pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+
+
+def wait_peer_ports(coin: Coin, timeout: float = 60.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if port_open("127.0.0.1", coin.peer_rpc_port) and port_open("127.0.0.1", coin.peer_p2p_port):
+            return
+        time.sleep(0.5)
+    raise RuntimeError(f"{coin.ticker} peer daemon did not open RPC/P2P ports")
+
+
+def connect_peer(coin: Coin, timeout: float = 30.0) -> None:
+    try:
+        rpc_call(coin, "addnode", [f"127.0.0.1:{coin.peer_p2p_port}", "onetry"], timeout=3)
+    except Exception:
+        pass
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            info = rpc_call(coin, "getnetworkinfo", timeout=3)
+            if int(info.get("connections", 0)) > 0:
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    raise RuntimeError(f"{coin.ticker} did not connect to its local peer")
+
+
+def stop_pid(path: Path, grace: float = 10.0) -> bool:
+    pid = read_pid(path)
+    if not pid_running(pid):
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return True
+    assert pid is not None
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except OSError:
+        os.kill(pid, signal.SIGTERM)
+    deadline = time.time() + grace
+    while time.time() < deadline:
+        if not pid_running(pid):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return True
+        time.sleep(0.2)
+    return False
+
+
+def ensure_pool_wallet(coin: Coin) -> str:
+    wallets = rpc_call(coin, "listwallets")
+    if "pool" not in wallets:
+        try:
+            rpc_call(coin, "loadwallet", ["pool"])
+        except Exception:
+            try:
+                rpc_call(coin, "createwallet", ["pool"])
+            except Exception:
+                rpc_call(coin, "createwallet", ["pool", False, False, "", False, False])
+    try:
+        return str(rpc_call(coin, "getnewaddress", ["", "bech32"], wallet="pool"))
+    except Exception:
+        return str(rpc_call(coin, "getnewaddress", [], wallet="pool"))
+
+
+def pool_command(addresses: dict[str, str]) -> list[str]:
+    parent = coin_by_ticker("BLC")
+    command = [
+        str(POOL_BIN),
+        "-stratum", "0.0.0.0:3334",
+        "-rpc", "127.0.0.1:19334",
+        "-proxy", "127.0.0.1:19335",
+        "-dashboard", "0.0.0.0:18080",
+        "-parent-rpc", f"http://{RPC_USER}:{RPC_PASSWORD}@127.0.0.1:{parent.rpc_port}/",
+        "-tracker-address", addresses["BLC"],
+        "-share-log", str(ROOT / "logs" / "share-logfile"),
+        "-pool-log", str(ROOT / "logs" / "eloipool.log"),
+        "-poll", "1s",
+        "-work-update", "5s",
+        "-base-difficulty", "1",
+        "-share-target", "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "-debug-gotwork",
+    ]
+    for coin in COINS:
+        if not coin.aux_name:
+            continue
+        command.extend([
+            "-aux-name", coin.aux_name,
+            "-aux-rpc", f"http://{RPC_USER}:{RPC_PASSWORD}@127.0.0.1:{coin.rpc_port}/",
+            "-aux-payout", addresses[coin.ticker],
+        ])
+    return command
+
+
+def start_pool(addresses: dict[str, str]) -> None:
+    pool_pid = ROOT / "run" / "eloipool.pid"
+    if pid_running(read_pid(pool_pid)) or port_open("127.0.0.1", 3334):
+        return
+    command = pool_command(addresses)
+    with (ROOT / "logs" / "eloipool.stdout.log").open("ab") as log:
+        proc = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    pool_pid.write_text(f"{proc.pid}\n", encoding="utf-8")
+
+
+def start_miner() -> None:
+    miner_pid = ROOT / "run" / "cpu-miner-loop.pid"
+    if pid_running(read_pid(miner_pid)):
+        return
+    loop_script = ROOT / "run" / "cpu-miner-loop.sh"
+    loop_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -u\n"
+        f"LOG={ROOT / 'logs' / 'cpu-miner.log'}\n"
+        "while true; do\n"
+        f"  STRATUM_HOST=127.0.0.1 STRATUM_PORT=3334 STRATUM_USER=dex-testnet STRATUM_SHARE_COUNT=1 STRATUM_TARGET_MODE=network python3 {CPU_MINER} >> \"$LOG\" 2>&1 || true\n"
+        "  sleep 1\n"
+        "done\n",
+        encoding="utf-8",
+    )
+    loop_script.chmod(0o755)
+    with (ROOT / "logs" / "cpu-miner-loop.stdout.log").open("ab") as log:
+        proc = subprocess.Popen([str(loop_script)], stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    miner_pid.write_text(f"{proc.pid}\n", encoding="utf-8")
+
+
+def collect_status() -> dict[str, Any]:
+    coins: dict[str, Any] = {}
+    for coin in COINS:
+        row: dict[str, Any] = {
+            "rpcPort": coin.rpc_port,
+            "p2pPort": coin.p2p_port,
+            "pid": read_pid(coin.pid_file),
+            "pidRunning": pid_running(read_pid(coin.pid_file)),
+            "rpcOpen": port_open("127.0.0.1", coin.rpc_port),
+        }
+        if row["rpcOpen"]:
+            try:
+                info = rpc_call(coin, "getblockchaininfo", timeout=3)
+                row["chain"] = info.get("chain")
+                row["blocks"] = info.get("blocks")
+                row["headers"] = info.get("headers")
+                row["softforks"] = info.get("softforks")
+            except Exception as exc:
+                row["rpcError"] = str(exc)
+            try:
+                network = rpc_call(coin, "getnetworkinfo", timeout=3)
+                row["connections"] = network.get("connections")
+                row["connections_in"] = network.get("connections_in")
+                row["connections_out"] = network.get("connections_out")
+            except Exception as exc:
+                row["networkError"] = str(exc)
+            try:
+                row["deploymentInfo"] = rpc_call(coin, "getdeploymentinfo", timeout=3)
+            except Exception as exc:
+                row["deploymentInfoError"] = str(exc)
+        row["peer"] = {
+            "rpcPort": coin.peer_rpc_port,
+            "p2pPort": coin.peer_p2p_port,
+            "pid": read_pid(coin.peer_pid_file),
+            "pidRunning": pid_running(read_pid(coin.peer_pid_file)),
+            "rpcOpen": port_open("127.0.0.1", coin.peer_rpc_port),
+            "p2pOpen": port_open("127.0.0.1", coin.peer_p2p_port),
+        }
+        coins[coin.ticker] = row
+    pool_pid = ROOT / "run" / "eloipool.pid"
+    miner_pid = ROOT / "run" / "cpu-miner-loop.pid"
+    return {
+        "root": str(ROOT),
+        "pool": {
+            "pid": read_pid(pool_pid),
+            "pidRunning": pid_running(read_pid(pool_pid)),
+            "stratumOpen": port_open("127.0.0.1", 3334),
+            "dashboard": "http://192.168.1.221:18080",
+        },
+        "miner": {
+            "pid": read_pid(miner_pid),
+            "pidRunning": pid_running(read_pid(miner_pid)),
+        },
+        "coins": coins,
+    }
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    installed = install_binaries(force=args.force_install)
+    addresses_path = ROOT / "evidence" / "pool-addresses.json"
+    for coin in COINS:
+        start_daemon(coin)
+    for coin in COINS:
+        wait_rpc(coin)
+    for coin in COINS:
+        start_peer_daemon(coin)
+    for coin in COINS:
+        wait_peer_ports(coin)
+        connect_peer(coin)
+    addresses = {coin.ticker: ensure_pool_wallet(coin) for coin in COINS}
+    addresses_path.write_text(json.dumps(addresses, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    start_pool(addresses)
+    deadline = time.time() + 20
+    while time.time() < deadline and not port_open("127.0.0.1", 3334):
+        time.sleep(0.5)
+    start_miner()
+    status = collect_status()
+    status["installed"] = installed
+    status["addresses"] = addresses
+    (ROOT / "evidence" / "status-start.json").write_text(json.dumps(status, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(status, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    status = collect_status()
+    (ROOT / "evidence" / "status-latest.json").write_text(json.dumps(status, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(status, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_stop(_args: argparse.Namespace) -> int:
+    ok = True
+    for name in ("cpu-miner-loop.pid", "eloipool.pid"):
+        ok = stop_pid(ROOT / "run" / name) and ok
+    for coin in COINS:
+        try:
+            if port_open("127.0.0.1", coin.peer_rpc_port):
+                rpc_call(coin, "stop", timeout=3, peer=True)
+        except Exception:
+            pass
+        ok = stop_pid(coin.peer_pid_file) and ok
+    for coin in COINS:
+        try:
+            if port_open("127.0.0.1", coin.rpc_port):
+                rpc_call(coin, "stop", timeout=3)
+        except Exception:
+            pass
+        ok = stop_pid(coin.pid_file) and ok
+    print(json.dumps({"ok": ok, "root": str(ROOT)}, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    start = sub.add_parser("start")
+    start.add_argument("--force-install", action="store_true")
+    sub.add_parser("status")
+    sub.add_parser("stop")
+    args = parser.parse_args(argv)
+    if args.cmd == "start":
+        return cmd_start(args)
+    if args.cmd == "status":
+        return cmd_status(args)
+    if args.cmd == "stop":
+        return cmd_stop(args)
+    raise AssertionError(args.cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fund_current_regnet_electrium.py
+++ b/scripts/fund_current_regnet_electrium.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Fund local and build-server Electrium regnet wallets from pool wallets.
+
+This is an operational helper for the 25.2 DEX regnet lane. It assumes the
+six 25.2 daemons are already running on the build-server current lane:
+BLC 51320, BBTC 51322, ELT 51324, LIT 51326, PHO 51328, UMO 51330.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path("/mnt/ram-build/dex25-hub-qa-20260526/current-regnet-pool")
+LOCAL_ADDRESSES = ROOT / "local-electrium-addresses.json"
+EVIDENCE = ROOT / "evidence" / "fund-electrium-wallets.json"
+MANIFEST = Path.home() / ".blakestream" / "electrium-hub" / "wallets.json"
+CORE_AUTH = base64.b64encode(b"dex-regnet:dex-regnet-pass").decode()
+
+COINS = {
+    "BLC": {"core_port": 51320, "electrium_port": 57101, "amount": "25"},
+    "BBTC": {"core_port": 51322, "electrium_port": 57102, "amount": "25"},
+    "PHO": {"core_port": 51328, "electrium_port": 57105, "amount": "1000"},
+    "ELT": {"core_port": 51324, "electrium_port": 57103, "amount": "25"},
+    "LIT": {"core_port": 51326, "electrium_port": 57104, "amount": "0.1"},
+    "UMO": {"core_port": 51330, "electrium_port": 57106, "amount": "0.001"},
+}
+
+
+def post_json(url: str, auth: str, method: str, params: list[Any], timeout: int = 120) -> Any:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"jsonrpc": "1.0", "id": "fund", "method": method, "params": params}).encode(),
+        headers={"content-type": "application/json", "authorization": "Basic " + auth},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as res:
+            body = json.loads(res.read())
+    except urllib.error.HTTPError as exc:
+        body = json.loads(exc.read())
+    if body.get("error"):
+        raise RuntimeError(f"{method} at {url}: {body['error']}")
+    return body.get("result")
+
+
+def core_rpc(port: int, method: str, params: list[Any] | None = None, wallet: str | None = None) -> Any:
+    path = f"/wallet/{wallet}" if wallet else ""
+    return post_json(f"http://127.0.0.1:{port}{path}", CORE_AUTH, method, params or [])
+
+
+def electrium_rpc_manifest() -> dict[str, dict[str, Any]]:
+    manifest = json.loads(MANIFEST.read_text())
+    rows: dict[str, dict[str, Any]] = {}
+    for row in manifest["variants"]:
+        ticker = str(row["ticker"]).upper()
+        rows[ticker] = row["config"]
+    return rows
+
+
+def electrium_rpc(ticker: str, method: str, params: list[Any] | None = None) -> Any:
+    cfg = electrium_rpc_manifest()[ticker]
+    port = int(cfg["rpcPort"])
+    auth = base64.b64encode(f"{cfg['rpcUser']}:{cfg['rpcPassword']}".encode()).decode()
+    return post_json(f"http://127.0.0.1:{port}", auth, method, params or [], timeout=30)
+
+
+def main() -> None:
+    local = json.loads(LOCAL_ADDRESSES.read_text())
+    EVIDENCE.parent.mkdir(parents=True, exist_ok=True)
+    results = []
+    for ticker, cfg in COINS.items():
+        core_port = int(cfg["core_port"])
+        amount = str(cfg["amount"])
+        build_addr = electrium_rpc(ticker, "createnewaddress")
+        pool_addr = core_rpc(core_port, "getnewaddress", ["", "bech32"], wallet="pool")
+        tx_local = core_rpc(core_port, "sendtoaddress", [local[ticker], amount], wallet="pool")
+        tx_build = core_rpc(core_port, "sendtoaddress", [build_addr, amount], wallet="pool")
+        core_rpc(core_port, "generatetoaddress", [1, pool_addr])
+        results.append({
+            "coin": ticker,
+            "amount": amount,
+            "localAddress": local[ticker],
+            "localTxid": tx_local,
+            "buildServerAddress": build_addr,
+            "buildServerTxid": tx_build,
+            "heightAfterConfirm": core_rpc(core_port, "getblockcount"),
+        })
+    payload = {"generatedAt": int(time.time()), "results": results}
+    EVIDENCE.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vps-regnet-mining-smoke.sh
+++ b/scripts/vps-regnet-mining-smoke.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-/root/blakestream-25.2-mining-test}"
+POOL_DIR="${POOL_DIR:-/home/sid/Blakestream-Eliopool-25.2-GO}"
+BIN_ROOT="${BIN_ROOT:-/root/blakestream-25.2-independent/bin}"
+RPC_USER="${RPC_USER:-user}"
+RPC_PASS="${RPC_PASS:-pass}"
+POOL_STRATUM="${POOL_STRATUM:-127.0.0.1:3334}"
+POOL_RPC="${POOL_RPC:-127.0.0.1:19334}"
+POOL_PROXY="${POOL_PROXY:-127.0.0.1:19335}"
+POOL_DASHBOARD="${POOL_DASHBOARD:-127.0.0.1:18080}"
+SHARE_COUNT="${SHARE_COUNT:-1}"
+SOLVE_COUNT="${SOLVE_COUNT:-1}"
+INCLUDE_BBTC="${INCLUDE_BBTC:-1}"
+REORG_CHECK="${REORG_CHECK:-0}"
+INVALID_AUXPOW_CHECK="${INVALID_AUXPOW_CHECK:-0}"
+MINER_USER="${MINER_USER:-783c0d31dbf6d7a5bd3d9f9b8e4b3efef0dbe123.regnet}"
+
+COINS=(
+  "BLC|Blakecoin|blakecoin|blakecoind|blakecoin-cli|blakecoin.conf|61320|61420"
+  "ELT|Electron|electron|electrond|electron-cli|electron.conf|61324|61424"
+  "LIT|Lithium|lithium|lithiumd|lithium-cli|lithium.conf|61326|61426"
+  "PHO|Photon|photon|photond|photon-cli|photon.conf|61328|61428"
+  "UMO|UniversalMolecule|universalmolecule|universalmoleculed|universalmolecule-cli|universalmolecule.conf|61330|61430"
+)
+if [[ "$INCLUDE_BBTC" == "1" ]]; then
+  COINS=(
+    "BLC|Blakecoin|blakecoin|blakecoind|blakecoin-cli|blakecoin.conf|61320|61420"
+    "BBTC|BlakeBitcoin|blakebitcoin|blakebitcoind|blakebitcoin-cli|blakebitcoin.conf|61322|61422"
+    "ELT|Electron|electron|electrond|electron-cli|electron.conf|61324|61424"
+    "LIT|Lithium|lithium|lithiumd|lithium-cli|lithium.conf|61326|61426"
+    "PHO|Photon|photon|photond|photon-cli|photon.conf|61328|61428"
+    "UMO|UniversalMolecule|universalmolecule|universalmoleculed|universalmolecule-cli|universalmolecule.conf|61330|61430"
+  )
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+evidence="$ROOT/evidence/regnet-eliopool-$timestamp"
+mkdir -p "$ROOT/datadirs" "$ROOT/run" "$ROOT/logs" "$evidence"
+
+"$POOL_DIR/scripts/vps-regnet-stop.sh" >/dev/null 2>&1 || true
+rm -rf "$ROOT/datadirs" "$ROOT/run" "$ROOT/logs"
+mkdir -p "$ROOT/datadirs" "$ROOT/run" "$ROOT/logs" "$evidence"
+
+split_spec() {
+  IFS='|' read -r CODE NAME BINDIR DAEMON CLI CONF RPC_PORT P2P_PORT <<<"$1"
+  DAEMON_PATH="$BIN_ROOT/$BINDIR/$DAEMON"
+  CLI_PATH="$BIN_ROOT/$BINDIR/$CLI"
+  DATADIR="$ROOT/datadirs/$BINDIR"
+  CONF_FILE="$DATADIR/$CONF"
+  PID_FILE="$ROOT/run/$BINDIR.pid"
+  LOG_FILE="$ROOT/logs/$BINDIR.log"
+}
+
+write_conf() {
+  mkdir -p "$DATADIR"
+  cat > "$CONF_FILE" <<EOF_CONF
+regtest=1
+server=1
+fallbackfee=0.0001
+testactivationheight=bip34@1
+testactivationheight=dersig@1
+testactivationheight=cltv@1
+testactivationheight=csv@1
+testactivationheight=segwit@1
+
+[regtest]
+listen=1
+txindex=1
+dnsseed=0
+upnp=0
+natpmp=0
+discover=0
+acceptnonstdtxn=1
+rpcbind=127.0.0.1
+rpcallowip=127.0.0.1
+rpcuser=$RPC_USER
+rpcpassword=$RPC_PASS
+rpcport=$RPC_PORT
+port=$P2P_PORT
+EOF_CONF
+  chmod 0600 "$CONF_FILE"
+}
+
+cli() {
+  "$CLI_PATH" -datadir="$DATADIR" -conf="$CONF_FILE" "$@"
+}
+
+wait_rpc() {
+  for _ in $(seq 1 120); do
+    if cli getblockchaininfo >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for $CODE RPC" >&2
+  return 1
+}
+
+create_pool_wallet() {
+  if ! cli listwallets 2>/dev/null | grep -q '"pool"'; then
+    cli createwallet pool false false "" false true true >/dev/null 2>&1 || cli loadwallet pool >/dev/null
+  fi
+}
+
+wallet_cli() {
+  "$CLI_PATH" -datadir="$DATADIR" -conf="$CONF_FILE" -rpcwallet=pool "$@"
+}
+
+for spec in "${COINS[@]}"; do
+  split_spec "$spec"
+  if [[ ! -x "$DAEMON_PATH" || ! -x "$CLI_PATH" ]]; then
+    echo "Missing binary for $CODE under $BIN_ROOT/$BINDIR" >&2
+    exit 1
+  fi
+  write_conf
+  "$DAEMON_PATH" -datadir="$DATADIR" -conf="$CONF_FILE" -daemonwait -pid="$PID_FILE" >"$LOG_FILE" 2>&1
+  wait_rpc
+  create_pool_wallet
+done
+
+declare -A ADDR
+declare -A HEIGHT_BEFORE
+declare -A HEIGHT_AFTER
+
+for spec in "${COINS[@]}"; do
+  split_spec "$spec"
+  ADDR[$CODE]="$(wallet_cli getnewaddress "" bech32)"
+  HEIGHT_BEFORE[$CODE]="$(cli getblockcount)"
+done
+
+parent_rpc="http://$RPC_USER:$RPC_PASS@127.0.0.1:61320/"
+aux_args=(
+  -aux-name Electron -aux-rpc "http://$RPC_USER:$RPC_PASS@127.0.0.1:61324/" -aux-payout "${ADDR[ELT]}"
+  -aux-name Lithium -aux-rpc "http://$RPC_USER:$RPC_PASS@127.0.0.1:61326/" -aux-payout "${ADDR[LIT]}"
+  -aux-name Photon -aux-rpc "http://$RPC_USER:$RPC_PASS@127.0.0.1:61328/" -aux-payout "${ADDR[PHO]}"
+  -aux-name UniversalMolecule -aux-rpc "http://$RPC_USER:$RPC_PASS@127.0.0.1:61330/" -aux-payout "${ADDR[UMO]}"
+)
+if [[ "$INCLUDE_BBTC" == "1" ]]; then
+  aux_args=(
+    -aux-name BlakeBitcoin -aux-rpc "http://$RPC_USER:$RPC_PASS@127.0.0.1:61322/" -aux-payout "${ADDR[BBTC]}"
+    "${aux_args[@]}"
+  )
+fi
+
+"$POOL_DIR/bin/eloipool" \
+  -stratum "$POOL_STRATUM" \
+  -rpc "$POOL_RPC" \
+  -proxy "$POOL_PROXY" \
+  -dashboard "$POOL_DASHBOARD" \
+  -parent-rpc "$parent_rpc" \
+  -tracker-address "${ADDR[BLC]}" \
+  -share-log "$ROOT/logs/share-logfile" \
+  -pool-log "$ROOT/logs/eloipool.log" \
+  -poll 1s \
+  -work-update 5s \
+  -base-difficulty 1 \
+  -share-target 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
+  -debug-gotwork \
+  "${aux_args[@]}" \
+  >"$ROOT/logs/eloipool.stdout" 2>&1 &
+echo $! > "$ROOT/run/eloipool.pid"
+
+for _ in $(seq 1 60); do
+  if grep -q "stratum listening" "$ROOT/logs/eloipool.log" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+run_miner_solve() {
+  local index="$1"
+  STRATUM_HOST="${POOL_STRATUM%:*}" \
+  STRATUM_PORT="${POOL_STRATUM##*:}" \
+  STRATUM_USER="$MINER_USER" \
+  STRATUM_SHARE_COUNT="$SHARE_COUNT" \
+  STRATUM_TARGET_MODE=network \
+  python3 "$POOL_DIR/deploy-bundle/cpu_miner.py" >"$evidence/cpu-miner-${index}.log" 2>&1
+  cat "$evidence/cpu-miner-${index}.log" >>"$evidence/cpu-miner.log"
+}
+
+for solve_index in $(seq 1 "$SOLVE_COUNT"); do
+  run_miner_solve "$solve_index"
+  sleep 1
+done
+
+sleep 3
+
+declare -A REORG_OLD
+declare -A REORG_NEW
+declare -A INVALID_AUXPOW
+
+if [[ "$INVALID_AUXPOW_CHECK" == "1" ]]; then
+  for spec in "${COINS[@]}"; do
+    split_spec "$spec"
+    [[ "$CODE" == "BLC" ]] && continue
+    aux_template="$(wallet_cli getnewaddress "" bech32 | xargs -I{} "$CLI_PATH" -datadir="$DATADIR" -conf="$CONF_FILE" createauxblock {} 2>&1 || true)"
+    aux_hash="$(printf '%s\n' "$aux_template" | python3 -c 'import json,sys; data=sys.stdin.read();
+try:
+    print(json.loads(data).get("hash",""))
+except Exception:
+    print("")
+')"
+    if [[ -n "$aux_hash" ]]; then
+      invalid_result="$("$CLI_PATH" -datadir="$DATADIR" -conf="$CONF_FILE" submitauxblock "$aux_hash" 00 2>&1 || true)"
+      INVALID_AUXPOW[$CODE]="$invalid_result"
+    else
+      INVALID_AUXPOW[$CODE]="createauxblock failed: $aux_template"
+    fi
+  done
+fi
+
+if [[ "$REORG_CHECK" == "1" ]]; then
+  for spec in "${COINS[@]}"; do
+    split_spec "$spec"
+    [[ "$CODE" == "BLC" ]] && continue
+    REORG_OLD[$CODE]="$(cli getbestblockhash)"
+    cli invalidateblock "${REORG_OLD[$CODE]}" >/dev/null
+  done
+  run_miner_solve "reorg"
+  sleep 3
+  for spec in "${COINS[@]}"; do
+    split_spec "$spec"
+    [[ "$CODE" == "BLC" ]] && continue
+    REORG_NEW[$CODE]="$(cli getbestblockhash)"
+  done
+fi
+
+for spec in "${COINS[@]}"; do
+  split_spec "$spec"
+  HEIGHT_AFTER[$CODE]="$(cli getblockcount)"
+  cli getblockchaininfo > "$evidence/${CODE,,}-blockchaininfo.json"
+  wallet_cli getwalletinfo > "$evidence/${CODE,,}-walletinfo.json"
+done
+
+{
+  echo "# VPS Regtest Eloipool Mining Smoke"
+  echo
+  echo "Timestamp UTC: $timestamp"
+  echo
+  echo "| Chain | Payout address | Height before | Height after | Delta |"
+  echo "| --- | --- | ---: | ---: | ---: |"
+  for spec in "${COINS[@]}"; do
+    split_spec "$spec"
+    before="${HEIGHT_BEFORE[$CODE]}"
+    after="${HEIGHT_AFTER[$CODE]}"
+    delta=$((after - before))
+    echo "| $NAME | ${ADDR[$CODE]} | $before | $after | $delta |"
+  done
+  echo
+  echo "Included BBTC: $INCLUDE_BBTC"
+  echo "Solve count: $SOLVE_COUNT"
+  echo "Invalid AuxPoW check: $INVALID_AUXPOW_CHECK"
+  echo "Reorg check: $REORG_CHECK"
+  echo
+  echo "Pool log: $ROOT/logs/eloipool.log"
+  echo "Miner log: $evidence/cpu-miner.log"
+  echo "Share log: $ROOT/logs/share-logfile"
+  if [[ "$INVALID_AUXPOW_CHECK" == "1" ]]; then
+    echo
+    echo "## Invalid AuxPoW Results"
+    echo
+    for spec in "${COINS[@]}"; do
+      split_spec "$spec"
+      [[ "$CODE" == "BLC" ]] && continue
+      echo "- $NAME: ${INVALID_AUXPOW[$CODE]}"
+    done
+  fi
+  if [[ "$REORG_CHECK" == "1" ]]; then
+    echo
+    echo "## Reorg Replacement Results"
+    echo
+    for spec in "${COINS[@]}"; do
+      split_spec "$spec"
+      [[ "$CODE" == "BLC" ]] && continue
+      echo "- $NAME: ${REORG_OLD[$CODE]} -> ${REORG_NEW[$CODE]}"
+    done
+  fi
+} > "$evidence/summary.md"
+
+for spec in "${COINS[@]}"; do
+  split_spec "$spec"
+  before="${HEIGHT_BEFORE[$CODE]}"
+  after="${HEIGHT_AFTER[$CODE]}"
+  min_delta="$SOLVE_COUNT"
+  if [[ "$REORG_CHECK" == "1" && "$CODE" == "BLC" ]]; then
+    min_delta=$((SOLVE_COUNT + 1))
+  fi
+  if [[ "$REORG_CHECK" == "1" && "$CODE" != "BLC" ]]; then
+    min_delta="$SOLVE_COUNT"
+  fi
+  if (( after - before < min_delta )); then
+    echo "$CODE did not advance enough: before=$before after=$after min_delta=$min_delta" >&2
+    exit 1
+  fi
+  if [[ "$REORG_CHECK" == "1" && "$CODE" != "BLC" && "${REORG_OLD[$CODE]}" == "${REORG_NEW[$CODE]}" ]]; then
+    echo "$CODE reorg replacement did not change best hash" >&2
+    exit 1
+  fi
+done
+
+echo "$evidence/summary.md"

--- a/scripts/vps-regnet-stop.sh
+++ b/scripts/vps-regnet-stop.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-/root/blakestream-25.2-mining-test}"
+POOL_DIR="${POOL_DIR:-/home/sid/Blakestream-Eliopool-25.2-GO}"
+BIN_ROOT="${BIN_ROOT:-/root/blakestream-25.2-independent/bin}"
+
+COINS=(
+  "BLC|blakecoin|blakecoind|blakecoin-cli|blakecoin.conf"
+  "BBTC|blakebitcoin|blakebitcoind|blakebitcoin-cli|blakebitcoin.conf"
+  "ELT|electron|electrond|electron-cli|electron.conf"
+  "LIT|lithium|lithiumd|lithium-cli|lithium.conf"
+  "PHO|photon|photond|photon-cli|photon.conf"
+  "UMO|universalmolecule|universalmoleculed|universalmolecule-cli|universalmolecule.conf"
+)
+
+if [[ -f "$ROOT/run/eloipool.pid" ]]; then
+  pid="$(cat "$ROOT/run/eloipool.pid" 2>/dev/null || true)"
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    kill "$pid" >/dev/null 2>&1 || true
+  fi
+fi
+pkill -f "$POOL_DIR/bin/eloipool" >/dev/null 2>&1 || true
+
+for spec in "${COINS[@]}"; do
+  IFS='|' read -r code bindir daemon cli conf <<<"$spec"
+  datadir="$ROOT/datadirs/$bindir"
+  conf_file="$datadir/$conf"
+  cli_path="$BIN_ROOT/$bindir/$cli"
+  if [[ -x "$cli_path" && -f "$conf_file" ]]; then
+    "$cli_path" -datadir="$datadir" -conf="$conf_file" stop >/dev/null 2>&1 || true
+  fi
+done
+
+sleep 3
+
+for spec in "${COINS[@]}"; do
+  IFS='|' read -r _code bindir daemon _cli _conf <<<"$spec"
+  pkill -f "$BIN_ROOT/$bindir/$daemon -datadir=$ROOT/datadirs/$bindir" >/dev/null 2>&1 || true
+done
+


### PR DESCRIPTION
Encode coinbase heights with Core-compatible script-number opcodes for BIP34.

Add witness commitment handling, txid-based merkle branches, and an optional share target override for private smoke tests.

Retain more aux merkle snapshots with bounded FIFO eviction and root-miss diagnostics.

Add regression tests and regnet/testnet smoke helpers.