### PR TITLE
Classify parent submitblock race statuses

### DIFF
--- a/internal/pool/service.go
+++ b/internal/pool/service.go
@@ -368,7 +368,9 @@ func (s *Service) SubmitShare(ctx context.Context, sub share.Submission) share.R
 				if parentAccepted {
 					s.parentFound.Add(1)
 				} else if err != nil {
-					s.logger.Warn("parent submitblock failed", "status", parentStatus, "error", err)
+					s.logger.Error("parent submitblock failed", "status", parentStatus, "error", err)
+				} else if isNonFatalParentSubmitStatus(parentStatus) {
+					s.logger.Info("parent submitblock race/stale", "status", parentStatus, "result", strings.TrimSpace(string(raw)))
 				} else {
 					s.logger.Warn("parent submitblock rejected", "status", parentStatus, "result", strings.TrimSpace(string(raw)))
 				}
@@ -406,12 +408,22 @@ func parentSubmitStatus(raw json.RawMessage, err error) (bool, string) {
 	}
 	var reject string
 	if json.Unmarshal(raw, &reject) == nil {
-		if strings.TrimSpace(reject) == "" {
+		reject = strings.TrimSpace(reject)
+		if reject == "" {
 			return true, "parent-accepted"
 		}
-		return false, "parent-rejected"
+		return false, reject
 	}
 	return false, "parent-rejected"
+}
+
+func isNonFatalParentSubmitStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "inconclusive", "duplicate", "stale", "stale-prevblk", "duplicate-inconclusive":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) getAuxFor(username string) (string, error) {

--- a/internal/pool/service_test.go
+++ b/internal/pool/service_test.go
@@ -126,12 +126,35 @@ func TestParentSubmitStatusReflectsDaemonResult(t *testing.T) {
 		t.Fatalf("null submit result = %v %s", accepted, status)
 	}
 	accepted, status = parentSubmitStatus(json.RawMessage(`"bad-txn"`), nil)
-	if accepted || status != "parent-rejected" {
+	if accepted || status != "bad-txn" {
 		t.Fatalf("rejection result = %v %s", accepted, status)
 	}
 	accepted, status = parentSubmitStatus(nil, errors.New("connection refused"))
 	if accepted || status != "parent-submit-failed" {
 		t.Fatalf("error result = %v %s", accepted, status)
+	}
+}
+
+func TestParentSubmitStatusClassifiesNonFatalStatuses(t *testing.T) {
+	tests := []struct {
+		status   string
+		nonFatal bool
+	}{
+		{"inconclusive", true},
+		{"duplicate", true},
+		{"stale", true},
+		{"stale-prevblk", true},
+		{"duplicate-inconclusive", true},
+		{"duplicate-invalid", false},
+		{"bad-cb-height", false},
+		{"bad-txnmrklroot", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := isNonFatalParentSubmitStatus(tt.status); got != tt.nonFatal {
+			t.Fatalf("isNonFatalParentSubmitStatus(%q) = %v, want %v", tt.status, got, tt.nonFatal)
+		}
 	}
 }
 


### PR DESCRIPTION
Preserve exact daemon submitblock status strings instead of collapsing every non-null result to parent-rejected.

Log normal race and stale parent statuses at INFO while keeping parentAccepted false for all non-null BIP22 responses.

Keep duplicate-invalid, bad-* statuses, and unknown non-null daemon responses on the rejected warning path.

Add tests covering accepted null responses, raw rejection status preservation, and non-fatal status classification.