### PR TITLE
Suppress terminal aux hash retries

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -655,12 +654,10 @@ func tickerForChainName(name string, fallback string) string {
 
 func auxSubmissionCacheKey(task auxSubmissionTask) string {
 	auxHash := strings.ToLower(strings.TrimSpace(task.auxHash))
-	auxpow := strings.TrimSpace(task.auxpow)
-	if auxHash == "" || auxpow == "" {
+	if auxHash == "" {
 		return ""
 	}
-	auxpowHash := sha256.Sum256([]byte(auxpow))
-	return strconv.Itoa(task.chain) + "|" + auxHash + "|" + hex.EncodeToString(auxpowHash[:])
+	return strconv.Itoa(task.chain) + "|" + auxHash
 }
 
 func (l *Listener) terminalAuxSubmission(task auxSubmissionTask) (auxSubmissionTerminalState, bool) {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -437,7 +437,7 @@ func TestSubmitAuxpowSuppressesDuplicateAcceptedHash(t *testing.T) {
 	}
 }
 
-func TestSubmitAuxpowSameHashDifferentPayloadStillSubmits(t *testing.T) {
+func TestSubmitAuxpowSuppressesSameHashDifferentPayloadAfterAccepted(t *testing.T) {
 	var submitCount atomic.Int64
 	aux := jsonRPCServer(t, map[string]rpcReply{
 		"submitauxblock": {result: true, count: &submitCount},
@@ -464,14 +464,14 @@ func TestSubmitAuxpowSameHashDifferentPayloadStillSubmits(t *testing.T) {
 
 	first := l.submitAuxpow(firstTask)
 	second := l.submitAuxpow(secondTask)
-	if !first.accepted || !second.accepted {
-		t.Fatalf("expected both different payloads accepted, got first=%#v second=%#v", first, second)
+	if !first.accepted {
+		t.Fatalf("expected first submit accepted, got %#v", first)
 	}
-	if first.suppressed || second.suppressed {
-		t.Fatalf("different payloads must not be suppressed, got first=%#v second=%#v", first, second)
+	if !second.suppressed || second.accepted || second.stale {
+		t.Fatalf("expected second same-hash payload suppressed after terminal accepted result, got %#v", second)
 	}
-	if submitCount.Load() != 2 {
-		t.Fatalf("submitauxblock calls = %d, want 2", submitCount.Load())
+	if submitCount.Load() != 1 {
+		t.Fatalf("submitauxblock calls = %d, want 1", submitCount.Load())
 	}
 }
 


### PR DESCRIPTION
Treat accepted or stale aux submissions as terminal for the chain and aux hash, not just for an exact AuxPoW payload. This prevents repeated stale retries after the aux daemon has already moved past that hash while still allowing non-terminal not-accepted candidates to continue.

Validated with go test ./... and a 10-minute live testnet pool sample: aux orphan retries stayed at zero, terminal suppressions increased, merged-mining readiness remained 5/5, and accepted block tables continued advancing.